### PR TITLE
Fix install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ dependent tokens continue to have access to your services.
 Currently the application is only available via Go, so to install you must have Go installed and run:
 
 ```
-go install -u github.com/TykTechnologies/tyk-sync
+go install -i github.com/TykTechnologies/tyk-sync
 ```
 
 This should make the `tyk-sync` command available to your console.


### PR DESCRIPTION
Looks like the `-u` switch is incorrect. Docs for `go install` only has a single switch, `-i`, which I presume is what was intended.

The command works ok when using `-i`.