### PR TITLE
Fixed authorization header for gateway

### DIFF
--- a/clients/gateway/certs.go
+++ b/clients/gateway/certs.go
@@ -32,7 +32,7 @@ func (c *Client) CreateCertificate(cert []byte) (string, error) {
 
 	req, err := http.NewRequest("POST", fullPath, body)
 	req.Header.Set("Content-Type", writer.FormDataContentType())
-	req.Header.Set("Authorization", c.secret)
+	req.Header.Set("X-Tyk-Authorization", c.secret)
 
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: c.InsecureSkipVerify},


### PR DESCRIPTION
Reference: https://github.com/TykTechnologies/tyk-sync/issues/15

The gateway expects "X-Tyk-Authorization" header instead of "Authorization". This should not impact communication with the dashboard since it has its own certs.go file