### PR TITLE
Update CreateAPI to allow definitions with same ListenPath

### DIFF
--- a/clients/gateway/client.go
+++ b/clients/gateway/client.go
@@ -115,7 +115,7 @@ func (c *Client) CreateAPI(def *apidef.APIDefinition) (string, error) {
 			return "", UseUpdateError
 		}
 
-		if api.Proxy.ListenPath == def.Proxy.ListenPath {
+		if api.Proxy.TargetURL == def.Proxy.TargetURL && api.Proxy.ListenPath == def.Proxy.ListenPath {
 			return "", UseUpdateError
 		}
 	}


### PR DESCRIPTION
CreateAPI checks whether any other API definitions listen to the same path, which is expected in case the base URL of the APIs is the same. You don't want overlapping endpoints. However, not all definitions have the same base URL (or Target URL), and if they don't, overlapping paths should be allowed. I think this check should be expanded to see if BOTH the target URL and listen path overlap with an already existing resource.