### PR TITLE
APIs with associated Policies synced are not working

### DIFF
--- a/clients/dashboard/apis.go
+++ b/clients/dashboard/apis.go
@@ -11,6 +11,8 @@ import (
 	"gopkg.in/mgo.v2/bson"
 )
 
+var apisMap = map[string]apidef.APIDefinition{}
+
 type APIResponse struct {
 	Message string
 	Meta    string
@@ -144,6 +146,7 @@ func (c *Client) CreateAPI(def *apidef.APIDefinition) (string, error) {
 		}
 		newAPIID := newAPIDef.APIDefinition.APIID
 		APIIDRelations[def.APIID] = newAPIID
+		apisMap[def.APIID] = newAPIDef.APIDefinition
 	}
 
 	return status.Meta, nil
@@ -320,6 +323,7 @@ func (c *Client) Sync(apiDefs []apidef.APIDefinition) error {
 
 	DashIDMap := map[string]int{}
 	GitIDMap := map[string]int{}
+	apisMap = make(map[string]apidef.APIDefinition, len(apis.Apis))
 
 	// Build the dash ID map
 	for i, api := range apis.Apis {
@@ -361,6 +365,8 @@ func (c *Client) Sync(apiDefs []apidef.APIDefinition) error {
 			api.Id = apis.Apis[dashIndex].Id
 			api.APIID = apis.Apis[dashIndex].APIID
 			updateAPIs = append(updateAPIs, api)
+			// We add the apis to update in the apisMap in case we need to update something about it latter
+			apisMap[apiDefs[index].APIID] = api
 		}
 	}
 
@@ -378,6 +384,8 @@ func (c *Client) Sync(apiDefs []apidef.APIDefinition) error {
 		_, ok := DashIDMap[key]
 		if !ok {
 			createAPIs = append(createAPIs, apiDefs[index])
+			// We add the apis to create in the apisMap in case we need to update something about it latter
+			apisMap[apiDefs[index].APIID] = apiDefs[index]
 		}
 	}
 

--- a/clients/dashboard/apis.go
+++ b/clients/dashboard/apis.go
@@ -65,7 +65,7 @@ func (c *Client) CreateAPI(def *apidef.APIDefinition) (string, error) {
 		return "", err
 	}
 
-	retainedIDs := false
+	hadDefinedAPIID := false
 
 	for _, api := range apis.Apis {
 		if api.APIID == def.APIID {
@@ -93,7 +93,7 @@ func (c *Client) CreateAPI(def *apidef.APIDefinition) (string, error) {
 
 	if def.APIID != "" {
 		// Retain the API ID
-		retainedIDs = true
+		hadDefinedAPIID = true
 	}
 
 	// Create
@@ -125,8 +125,8 @@ func (c *Client) CreateAPI(def *apidef.APIDefinition) (string, error) {
 		return "", fmt.Errorf("API request completed, but with error: %v", status.Message)
 	}
 
-	// Create will always reset the API ID on dashboard, if we want to retain it, we must use UPDATE
-	if retainedIDs {
+	//If the API HAD an already defined APIID, we have to modify the policies asociated to it.
+	if hadDefinedAPIID {
 		path := fullPath + "/" + status.Meta
 		getResp, err := grequests.Get(path, &grequests.RequestOptions{
 			Headers: map[string]string{

--- a/clients/dashboard/policies.go
+++ b/clients/dashboard/policies.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/TykTechnologies/tyk-sync/clients/objects"
+	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/kataras/go-errors"
 	"github.com/levigross/grequests"
 	"github.com/ongoingio/urljoin"
@@ -60,7 +61,7 @@ func (c *Client) CreatePolicy(pol *objects.Policy) (string, error) {
 	}
 
 	pol.FixPolicyAPIIDs(APIIDRelations)
-
+	pol.ID = ""
 	fullPath := urljoin.Join(c.url, endpointPolicies)
 	ro := &grequests.RequestOptions{
 		JSON: pol,
@@ -88,9 +89,40 @@ func (c *Client) CreatePolicy(pol *objects.Policy) (string, error) {
 		return "", fmt.Errorf("API request completed, but with error: %v", dbResp.Message)
 	}
 
-	fmt.Println("newPolicyID:", dbResp)
+	//We need to update the APIS where this policy was in an OIDC Provider and update them with the new policy ID
+	for _, def := range apisMap {
+		shouldUpdate := false
+		newAPIDef := def
 
-	return dbResp.Meta, nil
+		newAPIDef.OpenIDOptions.Providers = []apidef.OIDProviderConfig{}
+
+		for _, provider := range def.OpenIDOptions.Providers {
+			fixedProvider := apidef.OIDProviderConfig{}
+			fixedProvider.Issuer = provider.Issuer
+
+			clientsIDs := make(map[string]string, len(provider.ClientIDs))
+			for key, policyID := range provider.ClientIDs {
+				if provider.ClientIDs[key] == pol.MID.Hex() {
+					shouldUpdate = true
+					clientsIDs[key] = dbResp.Message
+				} else {
+					clientsIDs[key] = policyID
+				}
+			}
+			fixedProvider.ClientIDs = clientsIDs
+			newAPIDef.OpenIDOptions.Providers = append(newAPIDef.OpenIDOptions.Providers, fixedProvider)
+		}
+
+		if shouldUpdate {
+			err := c.UpdateAPI(&newAPIDef)
+			if err != nil {
+				fmt.Println("Error updating API with the new Policy ID:", err)
+				return "", err
+			}
+		}
+	}
+
+	return dbResp.Message, nil
 }
 
 func (c *Client) DeletePolicy(id string) error {
@@ -200,8 +232,6 @@ func (c *Client) UpdatePolicy(pol *objects.Policy) error {
 	if dbResp.Status != "OK" {
 		return fmt.Errorf("API request completed, but with error: %v", dbResp.Message)
 	}
-
-	fmt.Println("newPolicyID:", dbResp)
 
 	return nil
 }

--- a/clients/objects/policies.go
+++ b/clients/objects/policies.go
@@ -1,8 +1,9 @@
 package objects
 
 import (
-	"gopkg.in/mgo.v2/bson"
 	"time"
+
+	"gopkg.in/mgo.v2/bson"
 )
 
 type AccessSpec struct {
@@ -39,4 +40,21 @@ type Policy struct {
 		Acl       bool `bson:"acl" json:"acl"`
 	} `bson:"partitions" json:"partitions"`
 	LastUpdated string `bson:"last_updated" json:"last_updated"`
+}
+
+func (pol *Policy) FixPolicyAPIIDs(APIIDRelations map[string]string) {
+	apiIDToRemove := []string{}
+	for apiID, accessRights := range pol.AccessRights {
+		newAPIID, found := APIIDRelations[apiID]
+		if found {
+			newAccessRights := accessRights
+			newAccessRights.APIID = newAPIID
+			pol.AccessRights[newAPIID] = newAccessRights
+			apiIDToRemove = append(apiIDToRemove, apiID)
+		}
+	}
+
+	for _, apiID := range apiIDToRemove {
+		delete(pol.AccessRights, apiID)
+	}
 }


### PR DESCRIPTION
Issue: #25 

This PR tries to solve the problem generated when we try to sync APIs with associated Policies. 
This is mainly caused by a bug when we try to retain the api_id of the API and its relation with the policy access rights.
Also, when the API has OIDC configured you have to update the policy associated with it since it has changed.
