### PR TITLE
Issue-29

### DIFF
--- a/cli-publisher/dashboard.go
+++ b/cli-publisher/dashboard.go
@@ -2,6 +2,7 @@ package cli_publisher
 
 import (
 	"fmt"
+
 	"github.com/TykTechnologies/tyk-sync/clients/dashboard"
 	"github.com/TykTechnologies/tyk-sync/clients/objects"
 	"github.com/TykTechnologies/tyk/apidef"
@@ -32,27 +33,37 @@ func (p *DashboardPublisher) enforceOrgIDForPolicy(pol *objects.Policy) *objects
 }
 
 func (p *DashboardPublisher) Create(apiDef *apidef.APIDefinition) (string, error) {
-	c, err := dashboard.NewDashboardClient(p.Hostname, p.Secret)
+	c, err := dashboard.NewDashboardClient(p.Hostname, p.Secret, p.OrgOverride)
 	if err != nil {
 		return "", err
+	}
+	if p.OrgOverride == "" {
+		p.OrgOverride = c.OrgID
 	}
 
 	return c.CreateAPI(p.enforceOrgID(apiDef))
 }
 
 func (p *DashboardPublisher) Update(apiDef *apidef.APIDefinition) error {
-	c, err := dashboard.NewDashboardClient(p.Hostname, p.Secret)
+	c, err := dashboard.NewDashboardClient(p.Hostname, p.Secret, p.OrgOverride)
 	if err != nil {
 		return err
+	}
+	if p.OrgOverride == "" {
+		p.OrgOverride = c.OrgID
 	}
 
 	return c.UpdateAPI(p.enforceOrgID(apiDef))
 }
 
 func (p *DashboardPublisher) Sync(apiDefs []apidef.APIDefinition) error {
-	c, err := dashboard.NewDashboardClient(p.Hostname, p.Secret)
+	c, err := dashboard.NewDashboardClient(p.Hostname, p.Secret, p.OrgOverride)
 	if err != nil {
 		return err
+	}
+
+	if p.OrgOverride == "" {
+		p.OrgOverride = c.OrgID
 	}
 
 	if p.OrgOverride != "" {
@@ -79,27 +90,34 @@ func (p *DashboardPublisher) Name() string {
 }
 
 func (p *DashboardPublisher) CreatePolicy(pol *objects.Policy) (string, error) {
-	c, err := dashboard.NewDashboardClient(p.Hostname, p.Secret)
+	c, err := dashboard.NewDashboardClient(p.Hostname, p.Secret, p.OrgOverride)
 	if err != nil {
 		return "", err
 	}
-
-	return c.CreatePolicy(pol)
+	if p.OrgOverride == "" {
+		p.OrgOverride = c.OrgID
+	}
+	return c.CreatePolicy(p.enforceOrgIDForPolicy(pol))
 }
 
 func (p *DashboardPublisher) UpdatePolicy(pol *objects.Policy) error {
-	c, err := dashboard.NewDashboardClient(p.Hostname, p.Secret)
+	c, err := dashboard.NewDashboardClient(p.Hostname, p.Secret, p.OrgOverride)
 	if err != nil {
 		return err
 	}
-
-	return c.UpdatePolicy(pol)
+	if p.OrgOverride == "" {
+		p.OrgOverride = c.OrgID
+	}
+	return c.UpdatePolicy(p.enforceOrgIDForPolicy(pol))
 }
 
 func (p *DashboardPublisher) SyncPolicies(pols []objects.Policy) error {
-	c, err := dashboard.NewDashboardClient(p.Hostname, p.Secret)
+	c, err := dashboard.NewDashboardClient(p.Hostname, p.Secret, p.OrgOverride)
 	if err != nil {
 		return err
+	}
+	if p.OrgOverride == "" {
+		p.OrgOverride = c.OrgID
 	}
 
 	if p.OrgOverride != "" {

--- a/clients/dashboard/apis.go
+++ b/clients/dashboard/apis.go
@@ -43,6 +43,14 @@ func (c *Client) GetActiveID(def *apidef.APIDefinition) string {
 }
 
 func (c *Client) CreateAPI(def *apidef.APIDefinition) (string, error) {
+	if len(APIIDRelations) == 0 {
+		APIIDRelations = make(map[string]string)
+	}
+	if len(apisMap) == 0 {
+		apisMap = make(map[string]apidef.APIDefinition)
+		apisMap[def.APIID] = *def
+	}
+
 	fullPath := urljoin.Join(c.url, endpointAPIs)
 
 	ro := &grequests.RequestOptions{

--- a/clients/dashboard/client.go
+++ b/clients/dashboard/client.go
@@ -2,7 +2,12 @@ package dashboard
 
 import (
 	"errors"
+	"fmt"
 	"strings"
+
+	"github.com/TykTechnologies/tyk-sync/clients/objects"
+	"github.com/levigross/grequests"
+	"github.com/ongoingio/urljoin"
 )
 
 type Client struct {
@@ -10,12 +15,14 @@ type Client struct {
 	secret             string
 	isCloud            bool
 	InsecureSkipVerify bool
+	OrgID              string
 }
 
 const (
 	endpointAPIs     string = "/api/apis"
 	endpointPolicies string = "/api/portal/policies"
 	endpointCerts    string = "/api/certs"
+	endpointUsers    string = "/api/users"
 )
 
 var (
@@ -24,10 +31,41 @@ var (
 	UseCreateError    error = errors.New("Object does not exist, use create()")
 )
 
-func NewDashboardClient(url, secret string) (*Client, error) {
-	return &Client{
+func NewDashboardClient(url, secret, orgID string) (*Client, error) {
+	client := &Client{
 		url:     url,
 		secret:  secret,
 		isCloud: strings.Contains(url, "tyk.io"),
-	}, nil
+	}
+
+	if orgID == "" {
+		fullPath := urljoin.Join(url, endpointUsers)
+
+		ro := &grequests.RequestOptions{
+			Params: map[string]string{"p": "-2"},
+			Headers: map[string]string{
+				"Authorization": secret,
+			},
+		}
+
+		resp, err := grequests.Get(fullPath, ro)
+		if err != nil {
+			return client, err
+		}
+
+		if resp.StatusCode != 200 {
+			return client, fmt.Errorf("Error getting users from dashboard: %v for %v", resp.String(), fullPath)
+		}
+
+		users := objects.UsersResponse{}
+		if err := resp.JSON(&users); err != nil {
+			return client, err
+		}
+
+		if len(users.Users) > 0 {
+			client.OrgID = users.Users[0].OrgID
+		}
+	}
+
+	return client, nil
 }

--- a/clients/gateway/client.go
+++ b/clients/gateway/client.go
@@ -3,11 +3,12 @@ package gateway
 import (
 	"errors"
 	"fmt"
+
 	"github.com/TykTechnologies/tyk-sync/clients/objects"
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/levigross/grequests"
 	"github.com/ongoingio/urljoin"
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 )
 
 type Client struct {

--- a/clients/objects/users.go
+++ b/clients/objects/users.go
@@ -1,0 +1,10 @@
+package objects
+
+type UsersResponse struct {
+	Users []User `json:"users"`
+}
+
+type User struct {
+	OrgID     string `json:"org_id"`
+	AccessKey string `json:"access_key"`
+}

--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -4,13 +4,14 @@ import (
 	"fmt"
 
 	"encoding/json"
-	"github.com/TykTechnologies/tyk-sync/clients/dashboard"
-	"github.com/TykTechnologies/tyk-sync/clients/objects"
-	"github.com/TykTechnologies/tyk-sync/tyk-vcs"
-	"github.com/spf13/cobra"
 	"io/ioutil"
 	"os"
 	"path"
+
+	"github.com/TykTechnologies/tyk-sync/clients/dashboard"
+	"github.com/TykTechnologies/tyk-sync/clients/objects"
+	tyk_vcs "github.com/TykTechnologies/tyk-sync/tyk-vcs"
+	"github.com/spf13/cobra"
 )
 
 // dumpCmd represents the dump command
@@ -47,7 +48,7 @@ var dumpCmd = &cobra.Command{
 
 		fmt.Printf("Extracting APIs and Policies from %v\n", dbString)
 
-		c, err := dashboard.NewDashboardClient(dbString, secret)
+		c, err := dashboard.NewDashboardClient(dbString, secret, "")
 		if err != nil {
 			fmt.Println(err)
 		}

--- a/tyk-swagger/swagger.go
+++ b/tyk-swagger/swagger.go
@@ -4,9 +4,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/ongoingio/urljoin"
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 )
 
 type DefinitionObjectFormatAST struct {


### PR DESCRIPTION
Related #29 .

The idea behind this PR is to get orgID from dashboard automatically if no `-o` flag is passed to the execution.
It also solves some problems with `publish` command, since it wasn't enforcing the orgID given.