### PR TITLE
Add auto-build of packages on pushes to master

### DIFF
--- a/.github/actions/packagecloud/Dockerfile
+++ b/.github/actions/packagecloud/Dockerfile
@@ -1,0 +1,7 @@
+FROM ruby:2
+
+RUN gem install package_cloud
+COPY pc-wrapper.sh /pc-wrapper.sh
+
+ENTRYPOINT [ "/pc-wrapper.sh" ]
+CMD []

--- a/.github/actions/packagecloud/README.md
+++ b/.github/actions/packagecloud/README.md
@@ -1,0 +1,29 @@
+# PackageCloud docker action
+
+This action will push packages to PackageCloud via the package_cloud gem.
+
+## Inputs
+
+### `repo`
+
+**Required** The repo to push to.
+
+### `dir`
+
+**Required** Directory where the packages are. All rpms and debs found here will be pushed.
+
+## Outputs
+
+### `stdout`
+Stdout from the command execution.
+
+## Example usage
+
+```yaml
+uses: ./.github/actions/packagecloud
+env:
+  PACKAGECLOUD_TOKEN: ${{ secrets.PACKAGECLOUD_TOKEN }}
+with:
+  repo: 'tyk/tyk-sync-unstable'
+  dir: 'dist'
+```

--- a/.github/actions/packagecloud/action.yml
+++ b/.github/actions/packagecloud/action.yml
@@ -1,0 +1,21 @@
+# action.yml
+name: 'PackageCloud'
+description: 'Interact with PackageCloud via the package_cloud gem.'
+inputs:
+  repo:
+    description: 'PackageCloud repo name to use'
+    required: true
+  dir:
+    description: 'base directory where packages are'
+    required: true
+outputs:
+  rpmout:
+    description: 'Output from rpm uploads'
+  debout:
+    description: 'Output from deb uploads'
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+  args:
+    - ${{ inputs.repo }}
+    - ${{ inputs.dir }}

--- a/.github/actions/packagecloud/pc-wrapper.sh
+++ b/.github/actions/packagecloud/pc-wrapper.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -eo pipefail
+
+for v in el/6 el/7 ol/6 ol/7
+do
+    echo Pushing to $1/$v
+    package_cloud push --verbose --yes ${1}/${v} ${2}/*.rpm
+done | tee rpmout
+
+for v in ubuntu/xenial ubuntu/bionic debian/jessie debian/stretch debian/buster 
+do
+    echo Pushing to $1/$v
+    package_cloud push --yes ${1}/${v} ${2}/*.deb
+done | tee debout
+
+rpmout=$(< rpmout)
+debout=$(< debout)
+
+echo "::set-output name=rpmout::$rpmout"
+echo "::set-output name=debout::$debout"

--- a/.github/workflows/unstable-packages.yml
+++ b/.github/workflows/unstable-packages.yml
@@ -23,7 +23,7 @@ jobs:
           go-version: 1.14
             
       - name: Tag release
-        if: startsWith(github.ref, '/refs/heads/')
+        if: startsWith(github.ref, 'refs/heads/')
         run: git tag $(git describe --tags)
       
       - name: Run GoReleaser
@@ -33,3 +33,11 @@ jobs:
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push to PackageCloud
+        uses: ./.github/actions/packagecloud
+        env:
+          PACKAGECLOUD_TOKEN: ${{ secrets.PACKAGECLOUD_TOKEN }}
+        with:
+          repo: 'tyk/tyk-sync-unstable'
+          dir: 'dist'

--- a/.github/workflows/unstable-packages.yml
+++ b/.github/workflows/unstable-packages.yml
@@ -1,0 +1,35 @@
+name: Unstable packages
+
+on:
+  push:
+    branches:
+      - master
+      - release-**
+      - goreleaser/*
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+      
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+            
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.14
+            
+      - name: Tag release
+        if: startsWith(github.ref, '/refs/heads/')
+        run: git tag $(git describe --tags)
+      
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ tyk-sync.exe
 tmp/
 pre/
 tyk-sync
+/dist/config.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@ tyk-sync.exe
 tmp/
 pre/
 tyk-sync
-/dist/config.yaml
+dist/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,11 +8,9 @@ builds:
       - CGO_ENABLED=0
     goarch:
       - amd64
-      - arm
       - 386
       - arm64
     goarm:
-      - 6
       - 7
 
 nfpms:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,46 @@
+# Make sure to check the documentation at http://goreleaser.com
+before:
+  hooks:
+    - go mod download
+      
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goarch:
+      - amd64
+      - arm
+      - 386
+      - arm64
+    goarm:
+      - 6
+      - 7
+
+nfpms:
+  - vendor: "Tyk Technologies Ltd"
+    homepage: "https://tyk.io"
+    maintainer: "Tyk <info@tyk.io>"
+    description: "Maintain your Tyk API definitions under version control."
+    license: MPL 2.0
+    formats:
+      - deb
+      - rpm
+    bindir: "/opt/tyk-sync"
+
+archives:
+- replacements:
+    linux: Linux
+    386: i386
+    amd64: x86_64
+      
+checksum:
+  name_template: 'checksums.txt'
+    
+snapshot:
+  name_template: "{{ .Tag }}-next"
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+    - '^utils:'
+    - (?i)typo


### PR DESCRIPTION
Builds packages for i386, arm64 (v7) and amd64. Building both arm64 and arm breaks RPM uploads so it is a minimal set right now.

See a run of the workflow at https://github.com/TykTechnologies/tyk-sync/runs/830425742?check_suite_focus=true

See packages at https://packagecloud.io/tyk/tyk-sync-unstable