### PR TITLE
[TT-309] Feature/selection

### DIFF
--- a/clients/dashboard/apis.go
+++ b/clients/dashboard/apis.go
@@ -191,6 +191,35 @@ func (c *Client) FetchAPIs() ([]objects.DBApiDefinition, error) {
 	return apis.Apis, nil
 }
 
+func (c *Client) FetchAPI(apiID string) (objects.DBApiDefinition, error) {
+	api :=  objects.DBApiDefinition{}
+	fullPath := urljoin.Join(c.url, endpointAPIs, apiID)
+
+	ro := &grequests.RequestOptions{
+		Params: map[string]string{"p": "-2"},
+		Headers: map[string]string{
+			"Authorization": c.secret,
+		},
+		InsecureSkipVerify: c.InsecureSkipVerify,
+	}
+
+	resp, err := grequests.Get(fullPath, ro)
+	if err != nil {
+		return api, err
+	}
+
+	if resp.StatusCode != 200 {
+		return api, fmt.Errorf("API %v Returned error: %v for %v", apiID, resp.String(), fullPath)
+	}
+
+
+	if err := resp.JSON(&api); err != nil {
+		return api, err
+	}
+
+	return api, nil
+}
+
 func (c *Client) UpdateAPI(def *apidef.APIDefinition) error {
 	fullPath := urljoin.Join(c.url, endpointAPIs)
 

--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -66,26 +66,24 @@ var dumpCmd = &cobra.Command{
 		var errApisFetch error
 
 
-		if len(wantedAPIs) > 0 {
-			for _, APIID := range wantedAPIs{
-				api :=  objects.DBApiDefinition{}
-				api.APIID = APIID
-				apis = append(apis, api)
-			}
-
+		//building the api def objs from wantedAPIs
+		for _, APIID := range wantedAPIs{
+			api :=  objects.DBApiDefinition{}
+			api.APIID = APIID
+			apis = append(apis, api)
 		}
-		if len(wantedPolicies) > 0  {
-			for _,wantedPolicy := range wantedPolicies{
-				if !bson.IsObjectIdHex(wantedPolicy){
-					fmt.Println("Invalid selected Policiy ID:",wantedPolicy,".")
-					return
-				}
-				pol := objects.Policy{
-					ID: wantedPolicy,
-					MID: bson.ObjectIdHex(wantedPolicy),
-				}
-				policies = append(policies,pol)
+
+		//building the policies obj from wantedAPIs
+		for _,wantedPolicy := range wantedPolicies{
+			if !bson.IsObjectIdHex(wantedPolicy){
+				fmt.Printf("Invalid selected policy ID: %s.\n", wantedPolicy)
+				return
 			}
+			pol := objects.Policy{
+				ID: wantedPolicy,
+				MID: bson.ObjectIdHex(wantedPolicy),
+			}
+			policies = append(policies,pol)
 		}
 
 

--- a/cmd/publish.go
+++ b/cmd/publish.go
@@ -38,4 +38,6 @@ func init() {
 	publishCmd.Flags().StringP("secret", "s", "", "Your API secret")
 	publishCmd.Flags().StringP("path", "p", "", "Source directory for definition files (optional)")
 	publishCmd.Flags().Bool("test", false, "Use test publisher, output results to stdio")
+	publishCmd.Flags().StringSlice("policies",[]string{},"Specific Policies ids to publish")
+	publishCmd.Flags().StringSlice("apis",[]string{},"Specific Apis ids to publish")
 }

--- a/cmd/shared.go
+++ b/cmd/shared.go
@@ -155,7 +155,7 @@ func doGetData(cmd *cobra.Command, args []string) ([]apidef.APIDefinition, []obj
 		newL := 0
 		for _, apiID := range wantedAPIs{
 			for _, api := range filteredAPIS {
-				if apiID  == api.APIID {
+				if apiID  != api.APIID {
 					continue
 				}
 				filteredAPIS[newL] = api
@@ -170,7 +170,7 @@ func doGetData(cmd *cobra.Command, args []string) ([]apidef.APIDefinition, []obj
 		newL := 0
 		for _, polID := range wantedPolicies{
 			for _, pol := range filteredPolicies {
-				if (polID  == pol.ID) || (polID == pol.MID.Hex()) {
+				if !((polID  == pol.ID) || (polID == pol.MID.Hex())) {
 					continue
 				}
 				filteredPolicies[newL] = pol
@@ -221,9 +221,6 @@ func processPublish(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-
-	fmt.Println("::::TO PUBLISH::::")
-	
 
 	publisher, err := getPublisher(cmd, args)
 	if err != nil {

--- a/cmd/shared.go
+++ b/cmd/shared.go
@@ -130,6 +130,7 @@ func NewGetter(cmd *cobra.Command, args []string) (tyk_vcs.Getter, error) {
 }
 
 func doGetData(cmd *cobra.Command, args []string) ([]apidef.APIDefinition, []objects.Policy, error) {
+
 	getter, err := NewGetter(cmd, args)
 	if err != nil {
 		return nil, nil, err
@@ -140,7 +141,46 @@ func doGetData(cmd *cobra.Command, args []string) ([]apidef.APIDefinition, []obj
 		return nil, nil, err
 	}
 
-	return defs, pols, nil
+	wantedPolicies , _ := cmd.Flags().GetStringSlice("policies")
+	wantedAPIs , _ := cmd.Flags().GetStringSlice("apis")
+
+	if len(wantedAPIs) == 0 && len(wantedPolicies) == 0 {
+		return defs, pols, nil
+	}
+	filteredAPIS := []apidef.APIDefinition{}
+	filteredPolicies := []objects.Policy{}
+
+	if len(wantedAPIs) > 0 {
+		filteredAPIS = defs[:]
+		newL := 0
+		for _, apiID := range wantedAPIs{
+			for _, api := range filteredAPIS {
+				if apiID  == api.APIID {
+					continue
+				}
+				filteredAPIS[newL] = api
+				newL++
+			}
+		}
+		filteredAPIS = filteredAPIS[:newL]
+	}
+
+	if len(wantedPolicies) > 0 {
+		filteredPolicies=pols[:]
+		newL := 0
+		for _, polID := range wantedPolicies{
+			for _, pol := range filteredPolicies {
+				if (polID  == pol.ID) || (polID == pol.MID.Hex()) {
+					continue
+				}
+				filteredPolicies[newL] = pol
+				newL++
+			}
+		}
+		filteredPolicies = filteredPolicies[:newL]
+	}
+
+	return filteredAPIS, filteredPolicies, nil
 }
 
 func processSync(cmd *cobra.Command, args []string) error {
@@ -181,6 +221,9 @@ func processPublish(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+
+	fmt.Println("::::TO PUBLISH::::")
+	
 
 	publisher, err := getPublisher(cmd, args)
 	if err != nil {

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -40,4 +40,6 @@ func init() {
 	syncCmd.Flags().StringP("org", "o", "", "org ID override")
 	syncCmd.Flags().StringP("path", "p", "", "Source directory for definition files (optional)")
 	syncCmd.Flags().Bool("test", false, "Use test publisher, output results to stdio")
+	syncCmd.Flags().StringSlice("policies",[]string{},"Specific Policies ids to sync")
+	syncCmd.Flags().StringSlice("apis",[]string{},"Specific Apis ids to sync")
 }

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -50,4 +50,6 @@ func init() {
 	updateCmd.Flags().StringP("secret", "s", "", "Your API secret")
 	updateCmd.Flags().StringP("path", "p", "", "Source directory for definition files (optional)")
 	updateCmd.Flags().Bool("test", false, "Use test publisher, output results to stdio")
+	updateCmd.Flags().StringSlice("policies",[]string{},"Specific Policies ids to update")
+	updateCmd.Flags().StringSlice("apis",[]string{},"Specific Apis ids to update")
 }


### PR DESCRIPTION
**Removed the -a and -p** shortcuts and now it only accepts **`--apis` and `--policies`.** for selection. 

**Change the dump selection behavior:**
- If one or more APIs are selected, dump those APIs.
- If one or more Policies are selected, dump those Policies.
- If neither Policies nor APIs is specified, dump everything.

For example:
```
dump --apis="api_id_1" <- dumps only the API 1
dump --policies="pol_1" <- dumps only the POL 1
dump --apis="api_id_1"  --policies="pol_1"  <- dumps API 1 and POL 1
dump <- dump everything

```
Extended the selection support to **sync, publish, and update** commands. 

