### PR TITLE
[TT-482] Update Apidef struct

### DIFF
--- a/cli-publisher/dashboard.go
+++ b/cli-publisher/dashboard.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/TykTechnologies/tyk-sync/clients/dashboard"
 	"github.com/TykTechnologies/tyk-sync/clients/objects"
-	"github.com/TykTechnologies/tyk/apidef"
 )
 
 type DashboardPublisher struct {
@@ -14,7 +13,7 @@ type DashboardPublisher struct {
 	OrgOverride string
 }
 
-func (p *DashboardPublisher) enforceOrgID(apiDef *apidef.APIDefinition) *apidef.APIDefinition {
+func (p *DashboardPublisher) enforceOrgID(apiDef *objects.DBApiDefinition) *objects.DBApiDefinition {
 	if p.OrgOverride != "" {
 		fmt.Println("org override detected, setting.")
 		apiDef.OrgID = p.OrgOverride
@@ -32,7 +31,7 @@ func (p *DashboardPublisher) enforceOrgIDForPolicy(pol *objects.Policy) *objects
 	return pol
 }
 
-func (p *DashboardPublisher) Create(apiDef *apidef.APIDefinition) (string, error) {
+func (p *DashboardPublisher) Create(apiDef *objects.DBApiDefinition) (string, error) {
 	c, err := dashboard.NewDashboardClient(p.Hostname, p.Secret, p.OrgOverride)
 	if err != nil {
 		return "", err
@@ -44,7 +43,7 @@ func (p *DashboardPublisher) Create(apiDef *apidef.APIDefinition) (string, error
 	return c.CreateAPI(p.enforceOrgID(apiDef))
 }
 
-func (p *DashboardPublisher) Update(apiDef *apidef.APIDefinition) error {
+func (p *DashboardPublisher) Update(apiDef *objects.DBApiDefinition) error {
 	c, err := dashboard.NewDashboardClient(p.Hostname, p.Secret, p.OrgOverride)
 	if err != nil {
 		return err
@@ -56,7 +55,7 @@ func (p *DashboardPublisher) Update(apiDef *apidef.APIDefinition) error {
 	return c.UpdateAPI(p.enforceOrgID(apiDef))
 }
 
-func (p *DashboardPublisher) Sync(apiDefs []apidef.APIDefinition) error {
+func (p *DashboardPublisher) Sync(apiDefs []objects.DBApiDefinition) error {
 	c, err := dashboard.NewDashboardClient(p.Hostname, p.Secret, p.OrgOverride)
 	if err != nil {
 		return err
@@ -67,7 +66,7 @@ func (p *DashboardPublisher) Sync(apiDefs []apidef.APIDefinition) error {
 	}
 
 	if p.OrgOverride != "" {
-		fixedDefs := make([]apidef.APIDefinition, len(apiDefs))
+		fixedDefs := make([]objects.DBApiDefinition, len(apiDefs))
 		for i, a := range apiDefs {
 			newDef := a
 			newDef.OrgID = p.OrgOverride

--- a/cli-publisher/gateway.go
+++ b/cli-publisher/gateway.go
@@ -2,9 +2,9 @@ package cli_publisher
 
 import (
 	"errors"
+
 	"github.com/TykTechnologies/tyk-sync/clients/gateway"
 	"github.com/TykTechnologies/tyk-sync/clients/objects"
-	"github.com/TykTechnologies/tyk/apidef"
 )
 
 type GatewayPublisher struct {
@@ -12,7 +12,7 @@ type GatewayPublisher struct {
 	Hostname string
 }
 
-func (p *GatewayPublisher) Create(apiDef *apidef.APIDefinition) (string, error) {
+func (p *GatewayPublisher) Create(apiDef *objects.DBApiDefinition) (string, error) {
 	c, err := gateway.NewGatewayClient(p.Hostname, p.Secret)
 	if err != nil {
 		return "", err
@@ -21,7 +21,7 @@ func (p *GatewayPublisher) Create(apiDef *apidef.APIDefinition) (string, error) 
 	return c.CreateAPI(apiDef)
 }
 
-func (p *GatewayPublisher) Update(apiDef *apidef.APIDefinition) error {
+func (p *GatewayPublisher) Update(apiDef *objects.DBApiDefinition) error {
 	c, err := gateway.NewGatewayClient(p.Hostname, p.Secret)
 	if err != nil {
 		return err
@@ -43,7 +43,7 @@ func (p *GatewayPublisher) Reload() error {
 	return c.Reload()
 }
 
-func (p *GatewayPublisher) Sync(apiDefs []apidef.APIDefinition) error {
+func (p *GatewayPublisher) Sync(apiDefs []objects.DBApiDefinition) error {
 	c, err := gateway.NewGatewayClient(p.Hostname, p.Secret)
 	if err != nil {
 		return err

--- a/cli-publisher/mock.go
+++ b/cli-publisher/mock.go
@@ -2,13 +2,13 @@ package cli_publisher
 
 import (
 	"fmt"
+
 	"github.com/TykTechnologies/tyk-sync/clients/objects"
-	"github.com/TykTechnologies/tyk/apidef"
 )
 
 type MockPublisher struct{}
 
-func (mp MockPublisher) Create(apiDef *apidef.APIDefinition) (string, error) {
+func (mp MockPublisher) Create(apiDef *objects.DBApiDefinition) (string, error) {
 	newID := "654321"
 	fmt.Printf("Creating API ID: %v (on: %v to: %v)\n",
 		newID,
@@ -17,7 +17,7 @@ func (mp MockPublisher) Create(apiDef *apidef.APIDefinition) (string, error) {
 	return newID, nil
 }
 
-func (mp MockPublisher) Update(apiDef *apidef.APIDefinition) error {
+func (mp MockPublisher) Update(apiDef *objects.DBApiDefinition) error {
 	fmt.Printf("Updating API ID: %v (on: %v to: %v)\n",
 		apiDef.APIID,
 		apiDef.Proxy.ListenPath,
@@ -26,7 +26,7 @@ func (mp MockPublisher) Update(apiDef *apidef.APIDefinition) error {
 	return nil
 }
 
-func (mp MockPublisher) Sync(apiDef []apidef.APIDefinition) error {
+func (mp MockPublisher) Sync(apiDef []objects.DBApiDefinition) error {
 	return nil
 }
 

--- a/clients/dashboard/apis.go
+++ b/clients/dashboard/apis.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/TykTechnologies/tyk-sync/clients/objects"
-	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/levigross/grequests"
 	"github.com/ongoingio/urljoin"
 	uuid "github.com/satori/go.uuid"
@@ -32,11 +31,11 @@ func (c *Client) SetInsecureTLS(val bool) {
 	c.InsecureSkipVerify = val
 }
 
-func (c *Client) GetActiveID(def *apidef.APIDefinition) string {
+func (c *Client) GetActiveID(def *objects.DBApiDefinition) string {
 	return def.Id.Hex()
 }
 
-func (c *Client) CreateAPI(def *apidef.APIDefinition) (string, error) {
+func (c *Client) CreateAPI(def *objects.DBApiDefinition) (string, error) {
 	fullPath := urljoin.Join(c.url, endpointAPIs)
 
 	ro := &grequests.RequestOptions{
@@ -93,8 +92,8 @@ func (c *Client) CreateAPI(def *apidef.APIDefinition) (string, error) {
 	}
 
 	// Create
-	asDBDef := objects.DBApiDefinition{APIDefinition: *def}
-	c.fixDBDef(&asDBDef)
+	asDBDef := def
+	c.fixDBDef(asDBDef)
 
 	createResp, err := grequests.Post(fullPath, &grequests.RequestOptions{
 		JSON: asDBDef,
@@ -191,7 +190,7 @@ func (c *Client) FetchAPI(apiID string) (objects.DBApiDefinition, error) {
 	return api, nil
 }
 
-func (c *Client) UpdateAPI(def *apidef.APIDefinition) error {
+func (c *Client) UpdateAPI(def *objects.DBApiDefinition) error {
 	fullPath := urljoin.Join(c.url, endpointAPIs)
 
 	ro := &grequests.RequestOptions{
@@ -267,7 +266,7 @@ func (c *Client) UpdateAPI(def *apidef.APIDefinition) error {
 	}
 
 	// Update
-	asDBDef := objects.DBApiDefinition{APIDefinition: *def}
+	asDBDef := objects.DBApiDefinition{APIDefinition: def.APIDefinition}
 	c.fixDBDef(&asDBDef)
 
 	updatePath := urljoin.Join(c.url, endpointAPIs, def.Id.Hex())
@@ -299,10 +298,10 @@ func (c *Client) UpdateAPI(def *apidef.APIDefinition) error {
 	return nil
 }
 
-func (c *Client) Sync(apiDefs []apidef.APIDefinition) error {
+func (c *Client) Sync(apiDefs []objects.DBApiDefinition) error {
 	deleteAPIs := []string{}
-	updateAPIs := []apidef.APIDefinition{}
-	createAPIs := []apidef.APIDefinition{}
+	updateAPIs := []objects.DBApiDefinition{}
+	createAPIs := []objects.DBApiDefinition{}
 
 	// Fetch the running API list
 	fullPath := urljoin.Join(c.url, endpointAPIs)

--- a/clients/gateway/client.go
+++ b/clients/gateway/client.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/TykTechnologies/tyk-sync/clients/objects"
-	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/levigross/grequests"
 	"github.com/ongoingio/urljoin"
 	uuid "github.com/satori/go.uuid"
@@ -36,7 +35,7 @@ type APIMessage struct {
 	Message string `json:"message"`
 }
 
-type APISList []apidef.APIDefinition
+type APISList []objects.DBApiDefinition
 
 func NewGatewayClient(url, secret string) (*Client, error) {
 	return &Client{
@@ -49,7 +48,7 @@ func (c *Client) SetInsecureTLS(val bool) {
 	c.InsecureSkipVerify = val
 }
 
-func (c *Client) GetActiveID(def *apidef.APIDefinition) string {
+func (c *Client) GetActiveID(def *objects.DBApiDefinition) string {
 	return def.APIID
 }
 
@@ -80,13 +79,13 @@ func (c *Client) FetchAPIs() ([]objects.DBApiDefinition, error) {
 
 	retList := make([]objects.DBApiDefinition, len(apis))
 	for i, api := range apis {
-		retList[i] = objects.DBApiDefinition{APIDefinition: api}
+		retList[i] = api
 	}
 
 	return retList, nil
 }
 
-func (c *Client) CreateAPI(def *apidef.APIDefinition) (string, error) {
+func (c *Client) CreateAPI(def *objects.DBApiDefinition) (string, error) {
 	fullPath := urljoin.Join(c.url, endpointAPIs)
 
 	ro := &grequests.RequestOptions{
@@ -185,7 +184,7 @@ func (c *Client) Reload() error {
 	return nil
 }
 
-func (c *Client) UpdateAPI(def *apidef.APIDefinition) error {
+func (c *Client) UpdateAPI(def *objects.DBApiDefinition) error {
 	fullPath := urljoin.Join(c.url, endpointAPIs)
 
 	ro := &grequests.RequestOptions{
@@ -250,10 +249,10 @@ func (c *Client) UpdateAPI(def *apidef.APIDefinition) error {
 	return nil
 }
 
-func (c *Client) Sync(apiDefs []apidef.APIDefinition) error {
+func (c *Client) Sync(apiDefs []objects.DBApiDefinition) error {
 	deleteAPIs := []string{}
-	updateAPIs := []apidef.APIDefinition{}
-	createAPIs := []apidef.APIDefinition{}
+	updateAPIs := []objects.DBApiDefinition{}
+	createAPIs := []objects.DBApiDefinition{}
 
 	fullPath := urljoin.Join(c.url, endpointAPIs)
 

--- a/clients/interfaces/client.go
+++ b/clients/interfaces/client.go
@@ -2,13 +2,12 @@ package interfaces
 
 import (
 	"github.com/TykTechnologies/tyk-sync/clients/objects"
-	"github.com/TykTechnologies/tyk/apidef"
 )
 
 type APIManagementClient interface {
-	CreateAPI(def *apidef.APIDefinition) (string, error)
+	CreateAPI(def *objects.DBApiDefinition) (string, error)
 	FetchAPIs() ([]objects.DBApiDefinition, error)
-	UpdateAPI(def *apidef.APIDefinition) error
+	UpdateAPI(def *objects.DBApiDefinition) error
 	DeleteAPI(id string) error
 }
 
@@ -19,6 +18,6 @@ type CertificateManagementClient interface {
 type UniversalClient interface {
 	APIManagementClient
 	CertificateManagementClient
-	GetActiveID(def *apidef.APIDefinition) string
+	GetActiveID(def *objects.DBApiDefinition) string
 	SetInsecureTLS(bool)
 }

--- a/clients/objects/apidef.go
+++ b/clients/objects/apidef.go
@@ -5,8 +5,8 @@ import (
 	"gopkg.in/mgo.v2/bson"
 )
 
-func NewDefinition() *apidef.APIDefinition {
-	return &apidef.APIDefinition{}
+func NewDefinition() *DBApiDefinition {
+	return &DBApiDefinition{}
 }
 
 type DBApiDefinition struct {

--- a/clients/objects/apidef.go
+++ b/clients/objects/apidef.go
@@ -10,7 +10,7 @@ func NewDefinition() *DBApiDefinition {
 }
 
 type DBApiDefinition struct {
-	apidef.APIDefinition `bson:"api_definition,inline" json:"api_definition,inline"`
+	*apidef.APIDefinition `bson:"api_definition,inline" json:"api_definition,inline"`
 	HookReferences       []interface{} `bson:"hook_references" json:"hook_references"`
 	IsSite               bool          `bson:"is_site" json:"is_site"`
 	SortBy               int           `bson:"sort_by" json:"sort_by"`

--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/TykTechnologies/tyk/apidef"
 	"gopkg.in/mgo.v2/bson"
 
 	"encoding/json"
@@ -134,7 +135,19 @@ var dumpCmd = &cobra.Command{
 		dir, _ := cmd.Flags().GetString("target")
 		apiFiles := make([]string, len(apis))
 		for i, api := range apis {
-			j, jerr := json.MarshalIndent(api.APIDefinition, "", "  ")
+			type DumpAPIHelper struct{
+				apidef.APIDefinition
+				HookReferences       []interface{} `json:"hook_references"`
+				UserGroupOwners      []bson.ObjectId `json:"user_group_owners"`
+				UserOwners           []bson.ObjectId `json:"user_owners"`
+			}
+			helper := DumpAPIHelper{
+				api.APIDefinition,
+				api.HookReferences,
+				api.UserGroupOwners,
+				api.UserOwners,
+			}
+			j, jerr := json.MarshalIndent(helper, "", "  ")
 			if jerr != nil {
 				fmt.Printf("JSON Encoding error: %v\n", jerr.Error())
 				return

--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -2,7 +2,7 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/TykTechnologies/tyk/apidef"
+
 	"gopkg.in/mgo.v2/bson"
 
 	"encoding/json"
@@ -150,19 +150,8 @@ var dumpCmd = &cobra.Command{
 		dir, _ := cmd.Flags().GetString("target")
 		apiFiles := make([]string, len(apis))
 		for i, api := range apis {
-			type DumpAPIHelper struct{
-				apidef.APIDefinition
-				HookReferences       []interface{} `json:"hook_references"`
-				UserGroupOwners      []bson.ObjectId `json:"user_group_owners"`
-				UserOwners           []bson.ObjectId `json:"user_owners"`
-			}
-			helper := DumpAPIHelper{
-				api.APIDefinition,
-				api.HookReferences,
-				api.UserGroupOwners,
-				api.UserOwners,
-			}
-			j, jerr := json.MarshalIndent(helper, "", "  ")
+
+			j, jerr := json.MarshalIndent(api, "", "  ")
 			if jerr != nil {
 				fmt.Printf("JSON Encoding error: %v\n", jerr.Error())
 				return

--- a/cmd/shared.go
+++ b/cmd/shared.go
@@ -3,18 +3,18 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"io/ioutil"
+	"os"
+
 	"github.com/TykTechnologies/tyk-sync/cli-publisher"
 	"github.com/TykTechnologies/tyk-sync/clients/objects"
 	"github.com/TykTechnologies/tyk-sync/tyk-vcs"
-	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/spf13/cobra"
-	"io/ioutil"
-	"os"
 )
 
 var isGateway bool
 
-func doGitFetchCycle(getter tyk_vcs.Getter) ([]apidef.APIDefinition, []objects.Policy, error) {
+func doGitFetchCycle(getter tyk_vcs.Getter) ([]objects.DBApiDefinition, []objects.Policy, error) {
 	err := getter.FetchRepo()
 	if err != nil {
 		return nil, nil, err
@@ -129,7 +129,7 @@ func NewGetter(cmd *cobra.Command, args []string) (tyk_vcs.Getter, error) {
 	return tyk_vcs.NewGGetter(args[0], branch, auth)
 }
 
-func doGetData(cmd *cobra.Command, args []string) ([]apidef.APIDefinition, []objects.Policy, error) {
+func doGetData(cmd *cobra.Command, args []string) ([]objects.DBApiDefinition, []objects.Policy, error) {
 
 	getter, err := NewGetter(cmd, args)
 	if err != nil {
@@ -147,7 +147,7 @@ func doGetData(cmd *cobra.Command, args []string) ([]apidef.APIDefinition, []obj
 	if len(wantedAPIs) == 0 && len(wantedPolicies) == 0 {
 		return defs, pols, nil
 	}
-	filteredAPIS := []apidef.APIDefinition{}
+	filteredAPIS := []objects.DBApiDefinition{}
 	filteredPolicies := []objects.Policy{}
 
 	if len(wantedAPIs) > 0 {

--- a/cmd/shared.go
+++ b/cmd/shared.go
@@ -195,7 +195,7 @@ func processSync(cmd *cobra.Command, args []string) error {
 	}
 	fmt.Printf("Using publisher: %v\n", publisher.Name())
 
-	if len(pols) > 0 {
+	if len(pols) > 0 && !isGateway {
 		fmt.Println("Processing Policies...")
 		if err := publisher.SyncPolicies(pols); err != nil {
 			return err
@@ -250,24 +250,26 @@ func processPublish(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	for i, d := range pols {
-		if cmd.Use == "publish" {
-			fmt.Printf("Creating Policy %v: %v\n", i, d.Name)
-			id, err := publisher.CreatePolicy(&d)
-			if err != nil {
-				fmt.Printf("--> Status: FAIL, Error:%v\n", err)
-			} else {
-				fmt.Printf("--> Status: OK, ID:%v\n", id)
+	if !isGateway{
+		for i, d := range pols {
+			if cmd.Use == "publish" {
+				fmt.Printf("Creating Policy %v: %v\n", i, d.Name)
+				id, err := publisher.CreatePolicy(&d)
+				if err != nil {
+					fmt.Printf("--> Status: FAIL, Error:%v\n", err)
+				} else {
+					fmt.Printf("--> Status: OK, ID:%v\n", id)
+				}
 			}
-		}
 
-		if cmd.Use == "update" {
-			fmt.Printf("Updating Policy %v: %v\n", i, d.Name)
-			err := publisher.UpdatePolicy(&d)
-			if err != nil {
-				fmt.Printf("--> Status: FAIL, Error:%v\n", err)
-			} else {
-				fmt.Printf("--> Status: OK, ID:%v\n", d.Name)
+			if cmd.Use == "update" {
+				fmt.Printf("Updating Policy %v: %v\n", i, d.Name)
+				err := publisher.UpdatePolicy(&d)
+				if err != nil {
+					fmt.Printf("--> Status: FAIL, Error:%v\n", err)
+				} else {
+					fmt.Printf("--> Status: OK, ID:%v\n", d.Name)
+				}
 			}
 		}
 	}

--- a/tyk-swagger/swagger.go
+++ b/tyk-swagger/swagger.go
@@ -139,7 +139,7 @@ func newBlankDBDashDefinition() *objects.DBApiDefinition {
 		Pre:  make([]apidef.MiddlewareDefinition, 0),
 		Post: make([]apidef.MiddlewareDefinition, 0),
 	}
-	def := apidef.APIDefinition{
+	def := &apidef.APIDefinition{
 		ConfigData:         map[string]interface{}{},
 		ResponseProcessors: make([]apidef.ResponseProcessor, 0),
 		AllowedIPs:         make([]string, 0),
@@ -147,7 +147,7 @@ func newBlankDBDashDefinition() *objects.DBApiDefinition {
 		Tags:               make([]string, 0),
 	}
 	return &objects.DBApiDefinition{
-		APIDefinition:def,
+		APIDefinition:  def,
 	}
 }
 

--- a/tyk-swagger/swagger.go
+++ b/tyk-swagger/swagger.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/TykTechnologies/tyk-sync/clients/objects"
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/ongoingio/urljoin"
 	uuid "github.com/satori/go.uuid"
@@ -133,21 +134,24 @@ func (s *SwaggerAST) ConvertIntoApiVersion(versionName string) (apidef.VersionIn
 	return versionInfo, nil
 }
 
-func newBlankDBDashDefinition() *apidef.APIDefinition {
+func newBlankDBDashDefinition() *objects.DBApiDefinition {
 	EmptyMW := apidef.MiddlewareSection{
 		Pre:  make([]apidef.MiddlewareDefinition, 0),
 		Post: make([]apidef.MiddlewareDefinition, 0),
 	}
-	return &apidef.APIDefinition{
+	def := apidef.APIDefinition{
 		ConfigData:         map[string]interface{}{},
 		ResponseProcessors: make([]apidef.ResponseProcessor, 0),
 		AllowedIPs:         make([]string, 0),
 		CustomMiddleware:   EmptyMW,
 		Tags:               make([]string, 0),
 	}
+	return &objects.DBApiDefinition{
+		APIDefinition:def,
+	}
 }
 
-func CreateDefinitionFromSwagger(s *SwaggerAST, orgId string, versionName string) (*apidef.APIDefinition, error) {
+func CreateDefinitionFromSwagger(s *SwaggerAST, orgId string, versionName string) (*objects.DBApiDefinition, error) {
 	ad := newBlankDBDashDefinition()
 	ad.Name = s.Info.Title
 	ad.Active = true

--- a/tyk-vcs/getter.go
+++ b/tyk-vcs/getter.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/TykTechnologies/tyk-sync/clients/objects"
 	"github.com/TykTechnologies/tyk-sync/tyk-swagger"
+	"github.com/TykTechnologies/tyk/apidef"
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/src-d/go-billy.v4"
 	"gopkg.in/src-d/go-billy.v4/memfs"
@@ -164,8 +165,13 @@ func fetchAPIDefinitionsDirect(fs billy.Filesystem, spec *TykSourceSpec) ([]obje
 
 		ad := objects.DBApiDefinition{}
 		err = json.Unmarshal(rawDef, &ad)
-		if err != nil {
-			return nil, err
+		if err != nil || (ad.APIDefinition == nil){
+			def := apidef.APIDefinition{}
+			errSecondUnmarshal := json.Unmarshal(rawDef, &def)
+			if errSecondUnmarshal != nil {
+				return nil, err
+			}
+			ad.APIDefinition = &def
 		}
 
 		if defInfo.APIID != "" {
@@ -179,6 +185,7 @@ func fetchAPIDefinitionsDirect(fs billy.Filesystem, spec *TykSourceSpec) ([]obje
 		if defInfo.ORGID != "" {
 			ad.OrgID = defInfo.ORGID
 		}
+
 
 		defs[i] = ad
 	}

--- a/tyk-vcs/publisher.go
+++ b/tyk-vcs/publisher.go
@@ -2,14 +2,13 @@ package tyk_vcs
 
 import (
 	"github.com/TykTechnologies/tyk-sync/clients/objects"
-	"github.com/TykTechnologies/tyk/apidef"
 )
 
 type Publisher interface {
 	Name() string
-	Create(apiDef *apidef.APIDefinition) (string, error)
-	Update(apiDef *apidef.APIDefinition) error
-	Sync(apiDefs []apidef.APIDefinition) error
+	Create(apiDef *objects.DBApiDefinition) (string, error)
+	Update(apiDef *objects.DBApiDefinition) error
+	Sync(apiDefs []objects.DBApiDefinition) error
 	CreatePolicy(*objects.Policy) (string, error)
 	UpdatePolicy(*objects.Policy) error
 	SyncPolicies([]objects.Policy) error


### PR DESCRIPTION
Update and replace of `apidef.APIDefinition` for `objects.DBApiDefinition`since the dashboard uses the second one.

Also added a  backward-compatible way to parse the old dumps.


Tested using sync with an old dump file.
Tested dumping a new file and syncing again.
Tested using sync with a gateway only (without dashboard).