### PR TITLE
[TT-1093] Ensure nested API definition object is initialized when using dump command

### DIFF
--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/TykTechnologies/tyk/apidef"
 
 	"gopkg.in/mgo.v2/bson"
 
@@ -68,7 +69,7 @@ var dumpCmd = &cobra.Command{
 
 		//building the api def objs from wantedAPIs
 		for _, APIID := range wantedAPIs{
-			api :=  objects.DBApiDefinition{}
+			api :=  objects.DBApiDefinition{APIDefinition: &apidef.APIDefinition{}}
 			api.APIID = APIID
 			apis = append(apis, api)
 		}


### PR DESCRIPTION
Fix a bug that was introduced in 6b36e91270a9c287c40c93a1e1f6c3de409a9bd2