### PR TITLE
[TT-482]Change UpdateAPI object 

### DIFF
--- a/clients/dashboard/apis.go
+++ b/clients/dashboard/apis.go
@@ -128,7 +128,6 @@ func (c *Client) CreateAPI(def *objects.DBApiDefinition) (string, error) {
 		}
 	}
 
-
 	return status.Meta, nil
 
 }
@@ -162,7 +161,7 @@ func (c *Client) FetchAPIs() ([]objects.DBApiDefinition, error) {
 }
 
 func (c *Client) FetchAPI(apiID string) (objects.DBApiDefinition, error) {
-	api :=  objects.DBApiDefinition{}
+	api := objects.DBApiDefinition{}
 	fullPath := urljoin.Join(c.url, endpointAPIs, apiID)
 
 	ro := &grequests.RequestOptions{
@@ -181,7 +180,6 @@ func (c *Client) FetchAPI(apiID string) (objects.DBApiDefinition, error) {
 	if resp.StatusCode != 200 {
 		return api, fmt.Errorf("API %v Returned error: %v for %v", apiID, resp.String(), fullPath)
 	}
-
 
 	if err := resp.JSON(&api); err != nil {
 		return api, err
@@ -266,8 +264,8 @@ func (c *Client) UpdateAPI(def *objects.DBApiDefinition) error {
 	}
 
 	// Update
-	asDBDef := objects.DBApiDefinition{APIDefinition: def.APIDefinition}
-	c.fixDBDef(&asDBDef)
+	asDBDef := def
+	c.fixDBDef(asDBDef)
 
 	updatePath := urljoin.Join(c.url, endpointAPIs, def.Id.Hex())
 	updateResp, err := grequests.Put(updatePath, &grequests.RequestOptions{


### PR DESCRIPTION
### Description
Changing UpdateAPI object to do the PUT and don't lose ownership data when we update an API (or we try to retain ID's).

### Motivation
Retain the ownership data with publish, sync and update.

### Test
1- create API with Ownership 
![image](https://user-images.githubusercontent.com/25751713/100671794-d2f28f00-333f-11eb-92bf-3130c810420c.png)

2- dump the API
3- Delete the API from the dashboard.
4- tyk-sync publish / sync the dump.
5- Check in the dashboard if the ownership is still there.
![image](https://user-images.githubusercontent.com/25751713/100671974-09300e80-3340-11eb-87bc-b5543a330eaa.png)
