### PR TITLE
TT-6252 Fix Tyk OSS to Tyk Pro migration path

### DIFF
--- a/clients/dashboard/policies.go
+++ b/clients/dashboard/policies.go
@@ -50,7 +50,7 @@ func (c *Client) CreatePolicy(pol *objects.Policy) (string, error) {
 	}
 
 	for _, ePol := range existingPols {
-		if ePol.MID.Hex() == pol.MID.Hex() {
+		if ePol.MID == pol.MID {
 			return "", UsePolUpdateError
 		}
 
@@ -145,7 +145,7 @@ func (c *Client) UpdatePolicy(pol *objects.Policy) error {
 		return err
 	}
 
-	if pol.MID.Hex() == "" && pol.ID == "" {
+	if pol.MID == "" && pol.ID == "" {
 		return errors.New("--> Can't update policy without an ID or explicit (legacy) ID")
 	}
 
@@ -158,7 +158,7 @@ func (c *Client) UpdatePolicy(pol *objects.Policy) error {
 			break
 		}
 
-		if ePol.MID.Hex() == pol.MID.Hex() {
+		if ePol.MID == pol.MID {
 			found = true
 			break
 		}
@@ -168,7 +168,7 @@ func (c *Client) UpdatePolicy(pol *objects.Policy) error {
 		return UseCreateError
 	}
 
-	fullPath := urljoin.Join(c.url, endpointPolicies, pol.MID.Hex())
+	fullPath := urljoin.Join(c.url, endpointPolicies, pol.MID)
 
 	ro := &grequests.RequestOptions{
 		JSON: pol,
@@ -220,7 +220,7 @@ func (c *Client) SyncPolicies(pols []objects.Policy) error {
 		if pol.ID != "" {
 			DashIDMap[pol.ID] = i
 		} else {
-			DashIDMap[pol.MID.Hex()] = i
+			DashIDMap[pol.MID] = i
 		}
 	}
 
@@ -228,8 +228,8 @@ func (c *Client) SyncPolicies(pols []objects.Policy) error {
 	for i, pol := range pols {
 		if pol.ID != "" {
 			GitIDMap[pol.ID] = i
-		} else if pol.MID.Hex() != "" {
-			GitIDMap[pol.MID.Hex()] = i
+		} else if pol.MID != "" {
+			GitIDMap[pol.MID] = i
 		} else {
 			created := fmt.Sprintf("temp-pol-%v", uuid.NewV4().String())
 			GitIDMap[created] = i
@@ -251,7 +251,7 @@ func (c *Client) SyncPolicies(pols []objects.Policy) error {
 	for key, i := range DashIDMap {
 		_, ok := GitIDMap[key]
 		if !ok {
-			deletePols = append(deletePols, ePols[i].MID.Hex())
+			deletePols = append(deletePols, ePols[i].MID)
 		}
 	}
 

--- a/clients/objects/policies.go
+++ b/clients/objects/policies.go
@@ -4,7 +4,6 @@ import (
 	"time"
 
 	"github.com/jensneuse/graphql-go-tools/pkg/graphql"
-	"gopkg.in/mgo.v2/bson"
 )
 
 type AccessSpec struct {
@@ -50,7 +49,7 @@ type FieldLimits struct {
 }
 
 type Policy struct {
-	MID                bson.ObjectId               `bson:"_id,omitempty" json:"_id"`
+	MID                string                      `bson:"_id,omitempty" json:"_id"`
 	ID                 string                      `bson:"id,omitempty" json:"id"`
 	Name               string                      `bson:"name" json:"name"`
 	OrgID              string                      `bson:"org_id" json:"org_id"`

--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -57,24 +57,26 @@ var dumpCmd = &cobra.Command{
 		}
 
 		fmt.Println("> Fetching policies")
-		wantedPolicies, _ := cmd.Flags().GetStringSlice("policies")
-		wantedAPIs, _ := cmd.Flags().GetStringSlice("apis")
+		wantedPolicies , _ := cmd.Flags().GetStringSlice("policies")
+		wantedAPIs , _ := cmd.Flags().GetStringSlice("apis")
+
 
 		policies := []objects.Policy{}
 		apis := []objects.DBApiDefinition{}
 		var errPoliciesFetch error
 		var errApisFetch error
 
+
 		//building the api def objs from wantedAPIs
-		for _, APIID := range wantedAPIs {
-			api := objects.DBApiDefinition{APIDefinition: &apidef.APIDefinition{}}
+		for _, APIID := range wantedAPIs{
+			api :=  objects.DBApiDefinition{APIDefinition: &apidef.APIDefinition{}}
 			api.APIID = APIID
 			apis = append(apis, api)
 		}
 
 		//building the policies obj from wantedAPIs
-		for _, wantedPolicy := range wantedPolicies {
-			if !bson.IsObjectIdHex(wantedPolicy) {
+		for _,wantedPolicy := range wantedPolicies{
+			if !bson.IsObjectIdHex(wantedPolicy){
 				fmt.Printf("Invalid selected policy ID: %s.\n", wantedPolicy)
 				return
 			}
@@ -82,7 +84,7 @@ var dumpCmd = &cobra.Command{
 				ID:  wantedPolicy,
 				MID: wantedPolicy,
 			}
-			policies = append(policies, pol)
+			policies = append(policies,pol)
 		}
 
 		if len(wantedAPIs) == 0 && len(wantedPolicies) == 0 {
@@ -102,10 +104,12 @@ var dumpCmd = &cobra.Command{
 			}
 		}
 
+
+
 		fmt.Printf("--> Identified %v policies\n", len(policies))
 		if len(wantedPolicies) > 0 {
 			fmt.Println("--> Fetching and cleaning policy objects")
-		} else {
+		}else{
 			fmt.Println("--> Cleaning policy objects")
 		}
 		// A bug exists which causes decoding of the access rights to break,
@@ -127,7 +131,7 @@ var dumpCmd = &cobra.Command{
 		}
 		fmt.Printf("--> Fetched %v Policies\n", len(cleanPolicyObjects))
 
-		if len(wantedAPIs) > 0 {
+		if len(wantedAPIs) >0 {
 			fmt.Printf("--> Identified %v APIs\n", len(apis))
 			fmt.Println("--> Fetching and cleaning APIs objects")
 
@@ -163,37 +167,39 @@ var dumpCmd = &cobra.Command{
 			apiFiles[i] = fname
 		}
 
+
+
 		// If we have selected Policies specified we're going to check if we're importing all the necessary APIs
-		if len(wantedPolicies) > 0 {
-			for _, policy := range cleanPolicyObjects {
-				for _, accesRights := range policy.AccessRights {
+		if len(wantedPolicies) >0 {
+			for _, policy := range cleanPolicyObjects{
+				for _, accesRights := range policy.AccessRights{
 					found := false
-					for _, api := range apis {
+					for _, api := range apis{
 						if api.APIID == accesRights.APIID {
 							found = true
 						}
 					}
 					if !found {
-						fmt.Println("--> [WARNING] Policy ", policy.ID, " has access rights over API ID ", accesRights.APIID, " and that API it's not imported. It might cause some problems in the future.")
+						fmt.Println("--> [WARNING] Policy ",policy.ID," has access rights over API ID ",accesRights.APIID," and that API it's not imported. It might cause some problems in the future." )
 					}
 				}
 			}
 		}
 		// If we have selected APIs specified we're going to check if we're importing all the necessary policies
-		if len(wantedAPIs) > 0 {
+		if len(wantedAPIs) >0 {
 			//checking selected APIs  -  Policies integrity
-			for _, api := range apis {
-				for _, provider := range api.OpenIDOptions.Providers {
-					for _, id := range provider.ClientIDs {
+			for _, api := range apis{
+				for _, provider := range api.OpenIDOptions.Providers{
+					for _, id := range provider.ClientIDs{
 						found := false
-						for _, policy := range cleanPolicyObjects {
+						for _, policy := range cleanPolicyObjects{
 							if policy.ID == id {
-								found = true
+								found=true
 								break
 							}
 						}
 						if !found {
-							fmt.Println("--> [WARNING] Api ", api.APIID, " has the Policy ", id, " as an OIDC issuer policy and that policy is not imported. It might cause some problems in the future.")
+							fmt.Println("--> [WARNING] Api ",api.APIID," has the Policy ",id, " as an OIDC issuer policy and that policy is not imported. It might cause some problems in the future." )
 						}
 					}
 				}
@@ -268,6 +274,6 @@ func init() {
 	dumpCmd.Flags().StringP("branch", "b", "refs/heads/master", "Branch to use (defaults to refs/heads/master)")
 	dumpCmd.Flags().StringP("secret", "s", "", "Your API secret")
 	dumpCmd.Flags().StringP("target", "t", "", "Target directory for files")
-	dumpCmd.Flags().StringSlice("policies", []string{}, "Specific Policies ids to dump")
-	dumpCmd.Flags().StringSlice("apis", []string{}, "Specific Apis ids to dump")
+	dumpCmd.Flags().StringSlice("policies",[]string{},"Specific Policies ids to dump")
+	dumpCmd.Flags().StringSlice("apis",[]string{},"Specific Apis ids to dump")
 }

--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -57,36 +57,33 @@ var dumpCmd = &cobra.Command{
 		}
 
 		fmt.Println("> Fetching policies")
-		wantedPolicies , _ := cmd.Flags().GetStringSlice("policies")
-		wantedAPIs , _ := cmd.Flags().GetStringSlice("apis")
-
+		wantedPolicies, _ := cmd.Flags().GetStringSlice("policies")
+		wantedAPIs, _ := cmd.Flags().GetStringSlice("apis")
 
 		policies := []objects.Policy{}
 		apis := []objects.DBApiDefinition{}
 		var errPoliciesFetch error
 		var errApisFetch error
 
-
 		//building the api def objs from wantedAPIs
-		for _, APIID := range wantedAPIs{
-			api :=  objects.DBApiDefinition{APIDefinition: &apidef.APIDefinition{}}
+		for _, APIID := range wantedAPIs {
+			api := objects.DBApiDefinition{APIDefinition: &apidef.APIDefinition{}}
 			api.APIID = APIID
 			apis = append(apis, api)
 		}
 
 		//building the policies obj from wantedAPIs
-		for _,wantedPolicy := range wantedPolicies{
-			if !bson.IsObjectIdHex(wantedPolicy){
+		for _, wantedPolicy := range wantedPolicies {
+			if !bson.IsObjectIdHex(wantedPolicy) {
 				fmt.Printf("Invalid selected policy ID: %s.\n", wantedPolicy)
 				return
 			}
 			pol := objects.Policy{
-				ID: wantedPolicy,
-				MID: bson.ObjectIdHex(wantedPolicy),
+				ID:  wantedPolicy,
+				MID: wantedPolicy,
 			}
-			policies = append(policies,pol)
+			policies = append(policies, pol)
 		}
-
 
 		if len(wantedAPIs) == 0 && len(wantedPolicies) == 0 {
 			fmt.Println("> Fetching policies ")
@@ -105,19 +102,17 @@ var dumpCmd = &cobra.Command{
 			}
 		}
 
-
-
 		fmt.Printf("--> Identified %v policies\n", len(policies))
 		if len(wantedPolicies) > 0 {
 			fmt.Println("--> Fetching and cleaning policy objects")
-		}else{
+		} else {
 			fmt.Println("--> Cleaning policy objects")
 		}
 		// A bug exists which causes decoding of the access rights to break,
 		// so we should fetch individually
 		cleanPolicyObjects := make([]*objects.Policy, len(policies))
 		for i, p := range policies {
-			cp, err := c.FetchPolicy(p.MID.Hex())
+			cp, err := c.FetchPolicy(p.MID)
 			if err != nil {
 				fmt.Println(err)
 				return
@@ -125,14 +120,14 @@ var dumpCmd = &cobra.Command{
 
 			// Make sure we retain IDs
 			if cp.ID == "" {
-				cp.ID = cp.MID.Hex()
+				cp.ID = cp.MID
 			}
 
 			cleanPolicyObjects[i] = cp
 		}
 		fmt.Printf("--> Fetched %v Policies\n", len(cleanPolicyObjects))
 
-		if len(wantedAPIs) >0 {
+		if len(wantedAPIs) > 0 {
 			fmt.Printf("--> Identified %v APIs\n", len(apis))
 			fmt.Println("--> Fetching and cleaning APIs objects")
 
@@ -168,39 +163,37 @@ var dumpCmd = &cobra.Command{
 			apiFiles[i] = fname
 		}
 
-
-
 		// If we have selected Policies specified we're going to check if we're importing all the necessary APIs
-		if len(wantedPolicies) >0 {
-			for _, policy := range cleanPolicyObjects{
-				for _, accesRights := range policy.AccessRights{
+		if len(wantedPolicies) > 0 {
+			for _, policy := range cleanPolicyObjects {
+				for _, accesRights := range policy.AccessRights {
 					found := false
-					for _, api := range apis{
+					for _, api := range apis {
 						if api.APIID == accesRights.APIID {
 							found = true
 						}
 					}
 					if !found {
-						fmt.Println("--> [WARNING] Policy ",policy.ID," has access rights over API ID ",accesRights.APIID," and that API it's not imported. It might cause some problems in the future." )
+						fmt.Println("--> [WARNING] Policy ", policy.ID, " has access rights over API ID ", accesRights.APIID, " and that API it's not imported. It might cause some problems in the future.")
 					}
 				}
 			}
 		}
 		// If we have selected APIs specified we're going to check if we're importing all the necessary policies
-		if len(wantedAPIs) >0 {
+		if len(wantedAPIs) > 0 {
 			//checking selected APIs  -  Policies integrity
-			for _, api := range apis{
-				for _, provider := range api.OpenIDOptions.Providers{
-					for _, id := range provider.ClientIDs{
+			for _, api := range apis {
+				for _, provider := range api.OpenIDOptions.Providers {
+					for _, id := range provider.ClientIDs {
 						found := false
-						for _, policy := range cleanPolicyObjects{
+						for _, policy := range cleanPolicyObjects {
 							if policy.ID == id {
-								found=true
+								found = true
 								break
 							}
 						}
 						if !found {
-							fmt.Println("--> [WARNING] Api ",api.APIID," has the Policy ",id, " as an OIDC issuer policy and that policy is not imported. It might cause some problems in the future." )
+							fmt.Println("--> [WARNING] Api ", api.APIID, " has the Policy ", id, " as an OIDC issuer policy and that policy is not imported. It might cause some problems in the future.")
 						}
 					}
 				}
@@ -210,7 +203,7 @@ var dumpCmd = &cobra.Command{
 		policyFiles := make([]string, len(cleanPolicyObjects))
 		for i, pol := range cleanPolicyObjects {
 			if pol.ID == "" {
-				pol.ID = pol.MID.Hex()
+				pol.ID = pol.MID
 			}
 
 			j, jerr := json.MarshalIndent(pol, "", "  ")
@@ -275,6 +268,6 @@ func init() {
 	dumpCmd.Flags().StringP("branch", "b", "refs/heads/master", "Branch to use (defaults to refs/heads/master)")
 	dumpCmd.Flags().StringP("secret", "s", "", "Your API secret")
 	dumpCmd.Flags().StringP("target", "t", "", "Target directory for files")
-	dumpCmd.Flags().StringSlice("policies",[]string{},"Specific Policies ids to dump")
-	dumpCmd.Flags().StringSlice("apis",[]string{},"Specific Apis ids to dump")
+	dumpCmd.Flags().StringSlice("policies", []string{}, "Specific Policies ids to dump")
+	dumpCmd.Flags().StringSlice("apis", []string{}, "Specific Apis ids to dump")
 }

--- a/cmd/shared.go
+++ b/cmd/shared.go
@@ -107,7 +107,7 @@ func getAuthAndBranch(cmd *cobra.Command, args []string) ([]byte, string) {
 	if keyFile != "" {
 		sshKey, errSsh := ioutil.ReadFile(keyFile)
 		if errSsh != nil {
-			fmt.Println("Error reading ",keyFile," for github key:",errSsh)
+			fmt.Println("Error reading ", keyFile, " for github key:", errSsh)
 		}
 		auth = []byte(sshKey)
 	}
@@ -117,7 +117,7 @@ func getAuthAndBranch(cmd *cobra.Command, args []string) ([]byte, string) {
 }
 
 func NewGetter(cmd *cobra.Command, args []string) (tyk_vcs.Getter, error) {
-	filePath, _ :=  cmd.Flags().GetString("path")
+	filePath, _ := cmd.Flags().GetString("path")
 	if filePath != "" {
 		return tyk_vcs.NewFSGetter(filePath)
 	}
@@ -141,8 +141,8 @@ func doGetData(cmd *cobra.Command, args []string) ([]objects.DBApiDefinition, []
 		return nil, nil, err
 	}
 
-	wantedPolicies , _ := cmd.Flags().GetStringSlice("policies")
-	wantedAPIs , _ := cmd.Flags().GetStringSlice("apis")
+	wantedPolicies, _ := cmd.Flags().GetStringSlice("policies")
+	wantedAPIs, _ := cmd.Flags().GetStringSlice("apis")
 
 	if len(wantedAPIs) == 0 && len(wantedPolicies) == 0 {
 		return defs, pols, nil
@@ -153,9 +153,9 @@ func doGetData(cmd *cobra.Command, args []string) ([]objects.DBApiDefinition, []
 	if len(wantedAPIs) > 0 {
 		filteredAPIS = defs[:]
 		newL := 0
-		for _, apiID := range wantedAPIs{
+		for _, apiID := range wantedAPIs {
 			for _, api := range filteredAPIS {
-				if apiID  != api.APIID {
+				if apiID != api.APIID {
 					continue
 				}
 				filteredAPIS[newL] = api
@@ -166,11 +166,11 @@ func doGetData(cmd *cobra.Command, args []string) ([]objects.DBApiDefinition, []
 	}
 
 	if len(wantedPolicies) > 0 {
-		filteredPolicies=pols[:]
+		filteredPolicies = pols[:]
 		newL := 0
-		for _, polID := range wantedPolicies{
+		for _, polID := range wantedPolicies {
 			for _, pol := range filteredPolicies {
-				if !((polID  == pol.ID) || (polID == pol.MID.Hex())) {
+				if !((polID == pol.ID) || (polID == pol.MID)) {
 					continue
 				}
 				filteredPolicies[newL] = pol
@@ -250,7 +250,7 @@ func processPublish(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	if !isGateway{
+	if !isGateway {
 		for i, d := range pols {
 			if cmd.Use == "publish" {
 				fmt.Printf("Creating Policy %v: %v\n", i, d.Name)

--- a/cmd/shared.go
+++ b/cmd/shared.go
@@ -107,7 +107,7 @@ func getAuthAndBranch(cmd *cobra.Command, args []string) ([]byte, string) {
 	if keyFile != "" {
 		sshKey, errSsh := ioutil.ReadFile(keyFile)
 		if errSsh != nil {
-			fmt.Println("Error reading ", keyFile, " for github key:", errSsh)
+			fmt.Println("Error reading ",keyFile," for github key:",errSsh)
 		}
 		auth = []byte(sshKey)
 	}
@@ -117,7 +117,7 @@ func getAuthAndBranch(cmd *cobra.Command, args []string) ([]byte, string) {
 }
 
 func NewGetter(cmd *cobra.Command, args []string) (tyk_vcs.Getter, error) {
-	filePath, _ := cmd.Flags().GetString("path")
+	filePath, _ :=  cmd.Flags().GetString("path")
 	if filePath != "" {
 		return tyk_vcs.NewFSGetter(filePath)
 	}
@@ -141,8 +141,8 @@ func doGetData(cmd *cobra.Command, args []string) ([]objects.DBApiDefinition, []
 		return nil, nil, err
 	}
 
-	wantedPolicies, _ := cmd.Flags().GetStringSlice("policies")
-	wantedAPIs, _ := cmd.Flags().GetStringSlice("apis")
+	wantedPolicies , _ := cmd.Flags().GetStringSlice("policies")
+	wantedAPIs , _ := cmd.Flags().GetStringSlice("apis")
 
 	if len(wantedAPIs) == 0 && len(wantedPolicies) == 0 {
 		return defs, pols, nil
@@ -153,9 +153,9 @@ func doGetData(cmd *cobra.Command, args []string) ([]objects.DBApiDefinition, []
 	if len(wantedAPIs) > 0 {
 		filteredAPIS = defs[:]
 		newL := 0
-		for _, apiID := range wantedAPIs {
+		for _, apiID := range wantedAPIs{
 			for _, api := range filteredAPIS {
-				if apiID != api.APIID {
+				if apiID  != api.APIID {
 					continue
 				}
 				filteredAPIS[newL] = api
@@ -166,11 +166,11 @@ func doGetData(cmd *cobra.Command, args []string) ([]objects.DBApiDefinition, []
 	}
 
 	if len(wantedPolicies) > 0 {
-		filteredPolicies = pols[:]
+		filteredPolicies=pols[:]
 		newL := 0
-		for _, polID := range wantedPolicies {
+		for _, polID := range wantedPolicies{
 			for _, pol := range filteredPolicies {
-				if !((polID == pol.ID) || (polID == pol.MID)) {
+				if !((polID  == pol.ID) || (polID == pol.MID)) {
 					continue
 				}
 				filteredPolicies[newL] = pol
@@ -250,7 +250,7 @@ func processPublish(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	if !isGateway {
+	if !isGateway{
 		for i, d := range pols {
 			if cmd.Use == "publish" {
 				fmt.Printf("Creating Policy %v: %v\n", i, d.Name)


### PR DESCRIPTION
ObjectID parsing in the Policy object breaks support for explicit IDs for policies. Replacing the object type with a string should not be a breaking change.