### PR TITLE
TT-889  Version command

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,23 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+const VERSION = "1.2.2"
+
+func init() {
+	RootCmd.AddCommand(versionCmd)
+}
+
+var versionCmd = &cobra.Command{
+	Use:     "version",
+	Aliases: []string{"v"},
+	Short:   "Tyk-sync version",
+	Long:    `This command will show the current Tyk-Sync version.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("v" + VERSION)
+	},
+}


### PR DESCRIPTION
This PR adds a version command that prints the current tyk-sync version.

Usage:
`tyk-sync version`

Help:
`tyk-sync help` will show version as an available command with it's corresponding description.

Motivation:
https://tyktech.atlassian.net/browse/TT-889