### PR TITLE
[TT-6616] Add delete command

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,11 +71,12 @@ Usage:
   tyk-sync [command]
 
 Available Commands:
+  delete      Delete API and/or policy definitions from a gateway or dashboard
   dump        Dump will extract policies and APIs from a target (dashboard)
   help        Help about any command
   publish     publish API definitions from a Git repo or file system to a gateway or dashboard
   sync        Synchronise a github repo or file system with a gateway
-  update      A brief description of your command
+  update      Update a dashboard or gateway with APIs and policies
 
 Flags:
   -h, --help   help for tyk-sync

--- a/cli-publisher/dashboard.go
+++ b/cli-publisher/dashboard.go
@@ -55,6 +55,18 @@ func (p *DashboardPublisher) Update(apiDef *objects.DBApiDefinition) error {
 	return c.UpdateAPI(p.enforceOrgID(apiDef))
 }
 
+func (p *DashboardPublisher) Delete(id string) error {
+	c, err := dashboard.NewDashboardClient(p.Hostname, p.Secret, p.OrgOverride)
+	if err != nil {
+		return err
+	}
+	if p.OrgOverride == "" {
+		p.OrgOverride = c.OrgID
+	}
+
+	return c.DeleteAPI(id)
+}
+
 func (p *DashboardPublisher) Sync(apiDefs []objects.DBApiDefinition) error {
 	c, err := dashboard.NewDashboardClient(p.Hostname, p.Secret, p.OrgOverride)
 	if err != nil {
@@ -108,6 +120,17 @@ func (p *DashboardPublisher) UpdatePolicy(pol *objects.Policy) error {
 		p.OrgOverride = c.OrgID
 	}
 	return c.UpdatePolicy(p.enforceOrgIDForPolicy(pol))
+}
+
+func (p *DashboardPublisher) DeletePolicy(id string) error {
+	c, err := dashboard.NewDashboardClient(p.Hostname, p.Secret, p.OrgOverride)
+	if err != nil {
+		return err
+	}
+	if p.OrgOverride == "" {
+		p.OrgOverride = c.OrgID
+	}
+	return c.DeletePolicy(id)
 }
 
 func (p *DashboardPublisher) SyncPolicies(pols []objects.Policy) error {

--- a/cli-publisher/gateway.go
+++ b/cli-publisher/gateway.go
@@ -30,6 +30,15 @@ func (p *GatewayPublisher) Update(apiDef *objects.DBApiDefinition) error {
 	return c.UpdateAPI(apiDef)
 }
 
+func (p *GatewayPublisher) Delete(id string) error {
+	c, err := gateway.NewGatewayClient(p.Hostname, p.Secret)
+	if err != nil {
+		return err
+	}
+
+	return c.DeleteAPI(id)
+}
+
 func (p *GatewayPublisher) Name() string {
 	return "Gateway Publisher"
 }
@@ -57,6 +66,10 @@ func (p *GatewayPublisher) CreatePolicy(pol *objects.Policy) (string, error) {
 }
 
 func (p *GatewayPublisher) UpdatePolicy(pol *objects.Policy) error {
+	return errors.New("Policy handling not supported by Gateway publisher")
+}
+
+func (p *GatewayPublisher) DeletePolicy(id string) error {
 	return errors.New("Policy handling not supported by Gateway publisher")
 }
 

--- a/cli-publisher/mock.go
+++ b/cli-publisher/mock.go
@@ -26,6 +26,11 @@ func (mp MockPublisher) Update(apiDef *objects.DBApiDefinition) error {
 	return nil
 }
 
+func (mp MockPublisher) Delete(id string) error {
+	fmt.Printf("Deleting API ID: %v\n", id)
+	return nil
+}
+
 func (mp MockPublisher) Sync(apiDef []objects.DBApiDefinition) error {
 	return nil
 }
@@ -35,6 +40,10 @@ func (mp MockPublisher) CreatePolicy(pol *objects.Policy) (string, error) {
 }
 
 func (mp MockPublisher) UpdatePolicy(pol *objects.Policy) error {
+	return nil
+}
+
+func (mp MockPublisher) DeletePolicy(id string) error {
 	return nil
 }
 

--- a/clients/gateway/client.go
+++ b/clients/gateway/client.go
@@ -179,7 +179,7 @@ func (c *Client) Reload() error {
 	}
 
 	if status.Status != "ok" {
-		fmt.Errorf("API request completed, but with error: %v", status.Message)
+		return fmt.Errorf("API request completed, but with error: %v", status.Message)
 	}
 
 	return nil

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -1,0 +1,52 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/spf13/cobra"
+	"os"
+)
+
+var deleteCmd = &cobra.Command{
+	Use:   "delete",
+	Short: "Delete API and/or policy definitions from a gateway or dashboard",
+	Run: func(cmd *cobra.Command, args []string) {
+		verificationError := verifyArguments(cmd)
+		if verificationError != nil {
+			fmt.Println(verificationError)
+			os.Exit(1)
+		}
+		apis, apisFlagError := cmd.Flags().GetStringSlice("apis")
+		if apisFlagError != nil {
+			fmt.Printf("Error with the specified apis: %v\n", apisFlagError)
+			os.Exit(1)
+		}
+		pols, polsFlagError := cmd.Flags().GetStringSlice("policies")
+		if polsFlagError != nil {
+			fmt.Printf("Error with the specified policies: %+v\n", polsFlagError)
+			os.Exit(1)
+		}
+		if len(apis) == 0 && len(pols) == 0 {
+			fmt.Printf("Error: please specify --apis and/or --policies to delete\n\n")
+			cmd.Help()
+			os.Exit(1)
+		}
+
+		err := processDelete(cmd, args)
+		if err != nil {
+			fmt.Println("Error: ", err)
+			os.Exit(1)
+		}
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(deleteCmd)
+
+	deleteCmd.Flags().StringP("gateway", "g", "", "Fully qualified gateway target URL")
+	deleteCmd.Flags().StringP("dashboard", "d", "", "Fully qualified dashboard target URL")
+	deleteCmd.Flags().StringP("key", "k", "", "Key file location for auth (optional)")
+	deleteCmd.Flags().StringP("secret", "s", "", "Your API secret")
+	deleteCmd.Flags().Bool("test", false, "Use test mode, output results to stdio")
+	deleteCmd.Flags().StringSlice("policies", []string{}, "Specific Policies ids to delete")
+	deleteCmd.Flags().StringSlice("apis", []string{}, "Specific Apis ids to delete")
+}

--- a/cmd/shared.go
+++ b/cmd/shared.go
@@ -283,3 +283,52 @@ func processPublish(cmd *cobra.Command, args []string) error {
 	fmt.Println("Done")
 	return nil
 }
+
+func processDelete(cmd *cobra.Command, args []string) error {
+	publisher, err := getPublisher(cmd, args)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Using publisher: %v\n", publisher.Name())
+
+	apis, _ := cmd.Flags().GetStringSlice("apis")
+	pols, _ := cmd.Flags().GetStringSlice("policies")
+
+	failed := false
+	for i, apiID := range apis {
+		fmt.Printf("Deleting API %v: %v\n", i, apiID)
+		err := publisher.Delete(apiID)
+		if err != nil {
+			fmt.Printf("--> Status: FAIL, Error:%v\n", err)
+			failed = true
+		} else {
+			fmt.Printf("--> Status: OK, ID:%v\n", apiID)
+		}
+	}
+
+	if !isGateway {
+		for i, polID := range pols {
+			fmt.Printf("Deleting Policy %v: %v\n", i, polID)
+			err := publisher.DeletePolicy(polID)
+			if err != nil {
+				fmt.Printf("--> Status: FAIL, Error:%v\n", err)
+				failed = true
+			} else {
+				fmt.Printf("--> Status: OK, ID:%v\n", polID)
+			}
+		}
+	}
+
+	if isGateway {
+		if err := publisher.Reload(); err != nil {
+			return err
+		}
+	}
+
+	if failed {
+		return errors.New("delete command failed")
+	}
+
+	fmt.Println("Done")
+	return nil
+}

--- a/tyk-vcs/publisher.go
+++ b/tyk-vcs/publisher.go
@@ -8,9 +8,11 @@ type Publisher interface {
 	Name() string
 	Create(apiDef *objects.DBApiDefinition) (string, error)
 	Update(apiDef *objects.DBApiDefinition) error
+	Delete(id string) error
 	Sync(apiDefs []objects.DBApiDefinition) error
 	CreatePolicy(*objects.Policy) (string, error)
 	UpdatePolicy(*objects.Policy) error
+	DeletePolicy(id string) error
 	SyncPolicies([]objects.Policy) error
 	Reload() error
 }


### PR DESCRIPTION
I've added this command to enable APIs and policies to be explicitly deleted.

Although the `sync` command can delete these resources, there's no control over what exactly it deletes. This is fine if you want a Tyk environment to exactly mirror a Git branch state with no extraneous resources, but this doesn't work if you want to share a single Tyk environment with different sets of APIs managed independently.