### PR TITLE
TT-5555 Different approach for future compatibility

### DIFF
--- a/clients/dashboard/apis.go
+++ b/clients/dashboard/apis.go
@@ -3,7 +3,7 @@ package dashboard
 import (
 	"fmt"
 
-	"github.com/clarketm/json"
+	"encoding/json"
 
 	"github.com/TykTechnologies/tyk-sync/clients/objects"
 	"github.com/TykTechnologies/tyk/apidef"

--- a/clients/gateway/client.go
+++ b/clients/gateway/client.go
@@ -4,10 +4,9 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/clarketm/json"
+	"encoding/json"
 
 	"github.com/TykTechnologies/tyk-sync/clients/objects"
-	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/levigross/grequests"
 	"github.com/ongoingio/urljoin"
 	uuid "github.com/satori/go.uuid"
@@ -38,7 +37,7 @@ type APIMessage struct {
 	Message string `json:"message"`
 }
 
-type APISList []apidef.APIDefinition
+type APISList []objects.APIDefinition
 
 func NewGatewayClient(url, secret string) (*Client, error) {
 	return &Client{

--- a/clients/objects/apidef.go
+++ b/clients/objects/apidef.go
@@ -12,11 +12,17 @@ func NewDefinition() *DBApiDefinition {
 }
 
 type DBApiDefinition struct {
-	*apidef.APIDefinition `bson:"api_definition" json:"api_definition"`
-	OAS                   *oas.OAS        `json:"oas,omitempty"`
-	HookReferences        []interface{}   `bson:"hook_references" json:"hook_references"`
-	IsSite                bool            `bson:"is_site" json:"is_site"`
-	SortBy                int             `bson:"sort_by" json:"sort_by"`
-	UserGroupOwners       []bson.ObjectId `bson:"user_group_owners" json:"user_group_owners"`
-	UserOwners            []bson.ObjectId `bson:"user_owners" json:"user_owners"`
+	*APIDefinition  `bson:"api_definition" json:"api_definition"`
+	OAS             *oas.OAS        `json:"oas,omitempty"`
+	HookReferences  []interface{}   `bson:"hook_references" json:"hook_references"`
+	IsSite          bool            `bson:"is_site" json:"is_site"`
+	SortBy          int             `bson:"sort_by" json:"sort_by"`
+	UserGroupOwners []bson.ObjectId `bson:"user_group_owners" json:"user_group_owners"`
+	UserOwners      []bson.ObjectId `bson:"user_owners" json:"user_owners"`
+}
+
+type APIDefinition struct {
+	apidef.APIDefinition
+	Scopes                *apidef.Scopes                `json:"scopes,omitempty"`
+	AnalyticsPluginConfig *apidef.AnalyticsPluginConfig `json:"analytics_plugin,omitempty"`
 }

--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/TykTechnologies/tyk/apidef"
 
 	"gopkg.in/mgo.v2/bson"
 
@@ -67,7 +66,7 @@ var dumpCmd = &cobra.Command{
 
 		//building the api def objs from wantedAPIs
 		for _, APIID := range wantedAPIs {
-			api := objects.DBApiDefinition{APIDefinition: &apidef.APIDefinition{}}
+			api := objects.DBApiDefinition{APIDefinition: &objects.APIDefinition{}}
 			api.APIID = APIID
 			apis = append(apis, api)
 		}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.13
 
 require (
 	github.com/TykTechnologies/tyk v1.9.2-0.20220819105728-4d7f77afb22f
-	github.com/clarketm/json v1.17.1
 	github.com/jensneuse/graphql-go-tools v1.20.2
 	github.com/kataras/go-errors v0.0.3
 	github.com/levigross/grequests v0.0.0-20190908174114-253788527a1a

--- a/tyk-swagger/swagger.go
+++ b/tyk-swagger/swagger.go
@@ -139,13 +139,13 @@ func newBlankDBDashDefinition() *objects.DBApiDefinition {
 		Pre:  make([]apidef.MiddlewareDefinition, 0),
 		Post: make([]apidef.MiddlewareDefinition, 0),
 	}
-	def := &apidef.APIDefinition{
-		ConfigData:         map[string]interface{}{},
-		ResponseProcessors: make([]apidef.ResponseProcessor, 0),
-		AllowedIPs:         make([]string, 0),
-		CustomMiddleware:   EmptyMW,
-		Tags:               make([]string, 0),
-	}
+
+	def := &objects.APIDefinition{}
+	def.ConfigData = map[string]interface{}{}
+	def.ResponseProcessors = make([]apidef.ResponseProcessor, 0)
+	def.AllowedIPs = make([]string, 0)
+	def.CustomMiddleware = EmptyMW
+	def.Tags = make([]string, 0)
 	return &objects.DBApiDefinition{
 		APIDefinition: def,
 	}

--- a/tyk-vcs/getter.go
+++ b/tyk-vcs/getter.go
@@ -7,7 +7,7 @@ import (
 	"io/ioutil"
 
 	"github.com/TykTechnologies/tyk-sync/clients/objects"
-	"github.com/TykTechnologies/tyk-sync/tyk-swagger"
+	tyk_swagger "github.com/TykTechnologies/tyk-sync/tyk-swagger"
 	"github.com/TykTechnologies/tyk/apidef"
 	"gopkg.in/src-d/go-billy.v4"
 	"gopkg.in/src-d/go-billy.v4/memfs"
@@ -165,7 +165,7 @@ func fetchAPIDefinitionsDirect(fs billy.Filesystem, spec *TykSourceSpec) ([]obje
 		ad := objects.DBApiDefinition{}
 		err = json.Unmarshal(rawDef, &ad)
 		if err != nil || (ad.APIDefinition == nil) {
-			def := apidef.APIDefinition{}
+			def := objects.APIDefinition{}
 			errSecondUnmarshal := json.Unmarshal(rawDef, &def)
 			if errSecondUnmarshal != nil {
 				return nil, err


### PR DESCRIPTION
This PR drops the import github.com/clarketm/json lib since it needs go 1.17 to run and we're on 1.15 here.

To avoid the marshaling of new struct fields in dumps, I switched to an internal APIdef struct and override those new struct fields as a `*Struct`.
In that way, when using tyk-sync in older Tyk versions, those new fields are just not marshaled since the dashboard API don't contain them.


