### PR TITLE
updated the reviewers group in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,6 @@ updates:
       schedule:
         interval: "weekly"
       reviewers:
-        - "platform-squad"
+        - "TykTechnologies/platform-squad"
       # max number of pull requests that dependabot will open in tandem
       open-pull-requests-limit: 4

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,6 @@ updates:
       schedule:
         interval: "weekly"
       reviewers:
-        - "platform"
+        - "platform-squad"
       # max number of pull requests that dependabot will open in tandem
       open-pull-requests-limit: 4


### PR DESCRIPTION
The team name in GH changed from platform to platform-squad, then updated the dependabot file to pint to a valid name of group of reviewers