### PR TITLE
Fix/backwards apidef

### DIFF
--- a/clients/dashboard/apis.go
+++ b/clients/dashboard/apis.go
@@ -158,6 +158,9 @@ func (c *Client) CreateAPIs(apiDefs *[]objects.DBApiDefinition) error {
 			Headers: map[string]string{
 				"Authorization": c.secret,
 			},
+			Params: map[string]string{
+				"accept_additional_properties": "true",
+			},
 			InsecureSkipVerify: c.InsecureSkipVerify,
 		})
 

--- a/clients/dashboard/apis.go
+++ b/clients/dashboard/apis.go
@@ -263,6 +263,9 @@ func (c *Client) UpdateAPIs(apiDefs *[]objects.DBApiDefinition) error {
 			Headers: map[string]string{
 				"Authorization": c.secret,
 			},
+			Params: map[string]string{
+				"accept_additional_properties": "true",
+			},
 			InsecureSkipVerify: c.InsecureSkipVerify,
 		})
 

--- a/clients/gateway/client.go
+++ b/clients/gateway/client.go
@@ -232,6 +232,9 @@ func (c *Client) UpdateAPIs(apiDefs *[]objects.DBApiDefinition) error {
 				"x-tyk-authorization": c.secret,
 				"content-type":        "application/json",
 			},
+			Params: map[string]string{
+				"accept_additional_properties": "true",
+			},
 			InsecureSkipVerify: c.InsecureSkipVerify,
 		})
 

--- a/clients/objects/apidef.go
+++ b/clients/objects/apidef.go
@@ -25,5 +25,5 @@ type APIDefinition struct {
 	apidef.APIDefinition
 	Scopes                *apidef.Scopes                `json:"scopes,omitempty"`
 	AnalyticsPluginConfig *apidef.AnalyticsPluginConfig `json:"analytics_plugin,omitempty"`
-	ExternalOAuth         *apidef.ExternalOAuth         `json:"external_oauth"`
+	ExternalOAuth         *apidef.ExternalOAuth         `json:"external_oauth,omitempty"`
 }

--- a/clients/objects/apidef.go
+++ b/clients/objects/apidef.go
@@ -25,4 +25,5 @@ type APIDefinition struct {
 	apidef.APIDefinition
 	Scopes                *apidef.Scopes                `json:"scopes,omitempty"`
 	AnalyticsPluginConfig *apidef.AnalyticsPluginConfig `json:"analytics_plugin,omitempty"`
+	ExternalOAuth         *apidef.ExternalOAuth         `json:"external_oauth"`
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -6,7 +6,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const VERSION = "1.2.2"
+const VERSION = "1.2.4"
 
 func init() {
 	RootCmd.AddCommand(versionCmd)


### PR DESCRIPTION
This PR adds `accept_additional_properties` param to Update and Create API's calls to do the latest APIdef works with previous dashboard versions that support that params.