### PR TITLE
Merging to release-1.2: Fix/backwards apidef (#95)

### DIFF
--- a/clients/dashboard/apis.go
+++ b/clients/dashboard/apis.go
@@ -158,6 +158,9 @@ func (c *Client) CreateAPIs(apiDefs *[]objects.DBApiDefinition) error {
 			Headers: map[string]string{
 				"Authorization": c.secret,
 			},
+			Params: map[string]string{
+				"accept_additional_properties": "true",
+			},
 			InsecureSkipVerify: c.InsecureSkipVerify,
 		})
 
@@ -259,6 +262,9 @@ func (c *Client) UpdateAPIs(apiDefs *[]objects.DBApiDefinition) error {
 			JSON: data,
 			Headers: map[string]string{
 				"Authorization": c.secret,
+			},
+			Params: map[string]string{
+				"accept_additional_properties": "true",
 			},
 			InsecureSkipVerify: c.InsecureSkipVerify,
 		})

--- a/clients/gateway/client.go
+++ b/clients/gateway/client.go
@@ -232,6 +232,9 @@ func (c *Client) UpdateAPIs(apiDefs *[]objects.DBApiDefinition) error {
 				"x-tyk-authorization": c.secret,
 				"content-type":        "application/json",
 			},
+			Params: map[string]string{
+				"accept_additional_properties": "true",
+			},
 			InsecureSkipVerify: c.InsecureSkipVerify,
 		})
 

--- a/clients/objects/apidef.go
+++ b/clients/objects/apidef.go
@@ -25,4 +25,5 @@ type APIDefinition struct {
 	apidef.APIDefinition
 	Scopes                *apidef.Scopes                `json:"scopes,omitempty"`
 	AnalyticsPluginConfig *apidef.AnalyticsPluginConfig `json:"analytics_plugin,omitempty"`
+	ExternalOAuth         *apidef.ExternalOAuth         `json:"external_oauth,omitempty"`
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -6,11 +6,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-<<<<<<< HEAD
-const VERSION = "1.2.3"
-=======
 const VERSION = "1.2.4"
->>>>>>> 43a5f0f... Fix/backwards apidef (#95)
 
 func init() {
 	RootCmd.AddCommand(versionCmd)

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -6,7 +6,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
+<<<<<<< HEAD
 const VERSION = "1.2.3"
+=======
+const VERSION = "1.2.4"
+>>>>>>> 43a5f0f... Fix/backwards apidef (#95)
 
 func init() {
 	RootCmd.AddCommand(versionCmd)


### PR DESCRIPTION
Fix/backwards apidef (#95)

* using accept_additional_properties when creating APIs

* bumping version

* adding additional_params to update call

* adding additional_params to update call

* adding second backwards compatibility layer around external_oauth

* adding omitempty to external_oauth