### PR TITLE
add new examples command (TT-7409)

### DIFF
--- a/clients/examplesrepo/client.go
+++ b/clients/examplesrepo/client.go
@@ -1,0 +1,66 @@
+package examplesrepo
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+const (
+	RepoRootUrl   = "https://raw.githubusercontent.com/TykTechnologies/tyk-examples/main/"
+	RepoIndexFile = "repository.json"
+)
+
+type ExamplesClient struct {
+	RepositoryRootUrl *url.URL
+	httpClient        *http.Client
+}
+
+func NewExamplesClient(repoRootUrl string) (*ExamplesClient, error) {
+	parsedUrl, err := url.Parse(repoRootUrl)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ExamplesClient{
+		RepositoryRootUrl: parsedUrl,
+		httpClient: &http.Client{
+			Timeout: 5 * time.Second,
+		},
+	}, nil
+}
+
+func (e *ExamplesClient) GetRepositoryIndex() (*RepositoryIndex, error) {
+	targetUrl := fmt.Sprintf("%s/%s", e.RepositoryRootUrl.String(), RepoIndexFile)
+	fmt.Println(targetUrl)
+	req, err := http.NewRequest(http.MethodGet, targetUrl, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := e.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	// We cannot rely on status code 200 for GitHub, so we need a bit more flexibility here
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("example repository responded with unexpected status code: %d", resp.StatusCode)
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	repositoryIndex := &RepositoryIndex{}
+	err = json.Unmarshal(body, repositoryIndex)
+	if err != nil {
+		return nil, err
+	}
+
+	return repositoryIndex, nil
+}

--- a/clients/examplesrepo/client.go
+++ b/clients/examplesrepo/client.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	RepoRootUrl   = "https://raw.githubusercontent.com/TykTechnologies/tyk-examples/main/"
+	RepoRootUrl   = "https://raw.githubusercontent.com/TykTechnologies/tyk-examples/main"
 	RepoIndexFile = "repository.json"
 )
 
@@ -35,7 +35,6 @@ func NewExamplesClient(repoRootUrl string) (*ExamplesClient, error) {
 
 func (e *ExamplesClient) GetRepositoryIndex() (*RepositoryIndex, error) {
 	targetUrl := fmt.Sprintf("%s/%s", e.RepositoryRootUrl.String(), RepoIndexFile)
-	fmt.Println(targetUrl)
 	req, err := http.NewRequest(http.MethodGet, targetUrl, nil)
 	if err != nil {
 		return nil, err

--- a/clients/examplesrepo/client_test.go
+++ b/clients/examplesrepo/client_test.go
@@ -1,0 +1,116 @@
+package examplesrepo
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExamplesClient_GetRepositoryIndex(t *testing.T) {
+	successTestServer := createRepositoryTestServer(t, http.StatusOK)
+	notFoundTestServer := createRepositoryTestServer(t, http.StatusNotFound)
+	t.Cleanup(func() {
+		successTestServer.Close()
+		notFoundTestServer.Close()
+	})
+
+	t.Run("should return error if no success status code was captured", func(t *testing.T) {
+		client, err := NewExamplesClient(notFoundTestServer.URL)
+		require.NoError(t, err)
+
+		_, err = client.GetRepositoryIndex()
+		assert.Error(t, err)
+	})
+
+	t.Run("should successfully get repository index", func(t *testing.T) {
+		runSuccessfulTest := func(testServerURL string) func(t *testing.T) {
+			return func(t *testing.T) {
+				client, err := NewExamplesClient(testServerURL)
+				require.NoError(t, err)
+
+				index, err := client.GetRepositoryIndex()
+				assert.NoError(t, err)
+				assert.Equal(t, repositoryIndexModel, index)
+			}
+		}
+
+		t.Run("for status code 200", runSuccessfulTest(successTestServer.URL))
+	})
+}
+
+func createRepositoryTestServer(t *testing.T, statusCode int) *httptest.Server {
+	t.Helper()
+	repositoryIndexHandler := func(w http.ResponseWriter, r *http.Request) {
+		require.True(t, strings.HasSuffix(r.URL.Path, RepoIndexFile))
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(statusCode)
+		if statusCode >= 200 && statusCode <= 399 {
+			_, err := w.Write([]byte(repositoryIndexJson))
+			fmt.Println(err)
+		}
+	}
+	return httptest.NewServer(http.HandlerFunc(repositoryIndexHandler))
+}
+
+var repositoryIndexModel = &RepositoryIndex{
+	Examples: ExamplesCategories{
+		UDG: []ExampleMetadata{
+			{
+				Location:    "udg/first-demo",
+				Name:        "First UDG Demo",
+				Description: "This UDG demo is very simple",
+				Features: []string{
+					"GraphQL DataSource",
+					"REST DataSource",
+				},
+				MinTykVersion: "5.0",
+			},
+			{
+				Location:    "udg/complex-demo",
+				Name:        "Complex UDG Demo",
+				Description: "This UDG demo is very complex",
+				Features: []string{
+					"GraphQL DataSource",
+					"REST DataSource",
+					"Kafka DataSource",
+					"Subscriptions",
+				},
+				MinTykVersion: "5.0",
+			},
+		},
+	},
+}
+
+const repositoryIndexJson = `{
+	"examples": {
+		"udg": [
+			{
+				"location": "udg/first-demo",
+				"name": "First UDG Demo",
+				"description": "This UDG demo is very simple",
+				"features": [
+					"GraphQL DataSource",
+					"REST DataSource"
+				],
+				"minTykVersion": "5.0"
+			},
+			{
+				"location": "udg/complex-demo",
+				"name": "Complex UDG Demo",
+				"description": "This UDG demo is very complex",
+				"features": [
+					"GraphQL DataSource",
+					"REST DataSource",
+					"Kafka DataSource",
+					"Subscriptions"
+				],
+				"minTykVersion": "5.0"
+			}
+		]
+	}
+}`

--- a/clients/examplesrepo/models.go
+++ b/clients/examplesrepo/models.go
@@ -1,0 +1,17 @@
+package examplesrepo
+
+type RepositoryIndex struct {
+	Examples ExamplesCategories `json:"examples"`
+}
+
+type ExamplesCategories struct {
+	UDG []ExampleMetadata `json:"udg"`
+}
+
+type ExampleMetadata struct {
+	Location      string   `json:"location"`
+	Name          string   `json:"name"`
+	Description   string   `json:"description"`
+	Features      []string `json:"features"`
+	MinTykVersion string   `json:"minTykVersion"`
+}

--- a/clients/examplesrepo/utils.go
+++ b/clients/examplesrepo/utils.go
@@ -1,0 +1,22 @@
+package examplesrepo
+
+func IndexHasExamples(index *RepositoryIndex) bool {
+	if index == nil {
+		return false
+	}
+
+	return len(index.Examples.UDG) > 0
+}
+
+func MergeExamples(index *RepositoryIndex) []ExampleMetadata {
+	var examples []ExampleMetadata
+	if index == nil {
+		return examples
+	}
+
+	for _, udgExample := range index.Examples.UDG {
+		examples = append(examples, udgExample)
+	}
+
+	return examples
+}

--- a/clients/examplesrepo/utils_test.go
+++ b/clients/examplesrepo/utils_test.go
@@ -1,0 +1,60 @@
+package examplesrepo
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIndexHasExamples(t *testing.T) {
+	t.Run("should return false if index is nil", func(t *testing.T) {
+		assert.False(t, IndexHasExamples(nil))
+	})
+
+	t.Run("should return false if no examples are present", func(t *testing.T) {
+		index := RepositoryIndex{}
+		assert.False(t, IndexHasExamples(&index))
+	})
+
+	t.Run("should return true if index has at least one example", func(t *testing.T) {
+		index := RepositoryIndex{
+			Examples: ExamplesCategories{
+				UDG: []ExampleMetadata{
+					{
+						Location: "location",
+					},
+				},
+			},
+		}
+
+		assert.True(t, IndexHasExamples(&index))
+	})
+}
+
+func TestMergeExamples(t *testing.T) {
+	t.Run("should return empty slice when index is nil", func(t *testing.T) {
+		examples := MergeExamples(nil)
+		assert.Len(t, examples, 0)
+	})
+
+	t.Run("should merge examples successfully", func(t *testing.T) {
+		udgExample := ExampleMetadata{
+			Location: "udg",
+		}
+
+		index := RepositoryIndex{
+			Examples: ExamplesCategories{
+				UDG: []ExampleMetadata{
+					udgExample,
+				},
+			},
+		}
+
+		expectedExamples := []ExampleMetadata{
+			udgExample,
+		}
+
+		examples := MergeExamples(&index)
+		assert.Equal(t, expectedExamples, examples)
+	})
+}

--- a/cmd/examples.go
+++ b/cmd/examples.go
@@ -1,0 +1,27 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+// examplesCmd represents a command to show and publish examples from an examples repository
+var examplesCmd = &cobra.Command{
+	Use:   "examples",
+	Short: "Shows a list of all available tyk examples",
+	Long: `This command will show a list of all available tyk examples that are hosted on the official
+	GitHub repository. For more details please use the 'examples show' command.'`,
+	Run: func(cmd *cobra.Command, args []string) {
+		err := processExamplesList()
+		if err != nil {
+			fmt.Println("Error: ", err)
+			os.Exit(1)
+		}
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(examplesCmd)
+}

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/ongoingio/urljoin v0.0.0-20140909071054-8d88f7c81c3c
 	github.com/satori/go.uuid v1.2.0
 	github.com/spf13/cobra v1.0.0
+	github.com/stretchr/testify v1.8.1
 	gopkg.in/mgo.v2 v2.0.0-20190816093944-a6b53ec6cb22
 	gopkg.in/src-d/go-billy.v4 v4.3.2
 	gopkg.in/src-d/go-git.v4 v4.13.1

--- a/go.sum
+++ b/go.sum
@@ -833,6 +833,8 @@ github.com/streadway/amqp v0.0.0-20190404075320-75d898a42a94/go.mod h1:AZpEONHx3
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.2.0/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
@@ -840,8 +842,10 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
+github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/syndtr/goleveldb v0.0.0-20190318030020-c3a204f8e965/go.mod h1:9OrXJhf154huy1nPWmuSrkgjPUtUNhA+Zmy+6AESzuA=
 github.com/tidwall/gjson v1.11.0 h1:C16pk7tQNiH6VlCrtIXL1w8GaOsi1X3W8KDkE1BuYd4=


### PR DESCRIPTION
This PR adds a new command `examples` which will retrieve all official examples from `tyk-examples` repository at GitHub.
The output looks like this:
```
LOCATION            NAME                DESCRIPTION
udg/first-demo      First UDG Demo      This UDG demo is very simple
udg/complex-demo    Complex UDG Demo    This UDG demo is very complex
```