### PR TITLE
add examples show command

### DIFF
--- a/clients/examplesrepo/client.go
+++ b/clients/examplesrepo/client.go
@@ -64,6 +64,19 @@ func (e *ExamplesClient) GetRepositoryIndex() (*RepositoryIndex, error) {
 	return repositoryIndex, nil
 }
 
+func (e *ExamplesClient) GetAllExamples() ([]ExampleMetadata, error) {
+	index, err := e.GetRepositoryIndex()
+	if err != nil {
+		return nil, err
+	}
+
+	if !IndexHasExamples(index) {
+		return nil, err
+	}
+
+	return MergeExamples(index), nil
+}
+
 func (e *ExamplesClient) GetAllExamplesAsLocationIndexedMap() (map[string]ExampleMetadata, error) {
 	repositoryIndex, err := e.GetRepositoryIndex()
 	if err != nil {

--- a/clients/examplesrepo/client.go
+++ b/clients/examplesrepo/client.go
@@ -63,3 +63,12 @@ func (e *ExamplesClient) GetRepositoryIndex() (*RepositoryIndex, error) {
 
 	return repositoryIndex, nil
 }
+
+func (e *ExamplesClient) GetAllExamplesAsLocationIndexedMap() (map[string]ExampleMetadata, error) {
+	repositoryIndex, err := e.GetRepositoryIndex()
+	if err != nil {
+		return nil, err
+	}
+
+	return ExamplesAsLocationIndexedMap(repositoryIndex), nil
+}

--- a/clients/examplesrepo/client_test.go
+++ b/clients/examplesrepo/client_test.go
@@ -43,6 +43,22 @@ func TestExamplesClient_GetRepositoryIndex(t *testing.T) {
 	})
 }
 
+func TestExamplesClient_GetAllExamples(t *testing.T) {
+	successTestServer := createRepositoryTestServer(t, http.StatusOK)
+	t.Cleanup(func() {
+		successTestServer.Close()
+	})
+
+	t.Run("should successfully return all examples", func(t *testing.T) {
+		client, err := NewExamplesClient(successTestServer.URL)
+		require.NoError(t, err)
+
+		examples, err := client.GetAllExamples()
+		assert.Len(t, examples, len(repositoryIndexModel.Examples.UDG))
+		assert.Equal(t, repositoryIndexModel.Examples.UDG[0], examples[0])
+	})
+}
+
 func TestExamplesClient_GetAllExamplesAsLocationIndexedMap(t *testing.T) {
 	successTestServer := createRepositoryTestServer(t, http.StatusOK)
 	t.Cleanup(func() {

--- a/clients/examplesrepo/client_test.go
+++ b/clients/examplesrepo/client_test.go
@@ -43,6 +43,22 @@ func TestExamplesClient_GetRepositoryIndex(t *testing.T) {
 	})
 }
 
+func TestExamplesClient_GetAllExamplesAsLocationIndexedMap(t *testing.T) {
+	successTestServer := createRepositoryTestServer(t, http.StatusOK)
+	t.Cleanup(func() {
+		successTestServer.Close()
+	})
+
+	t.Run("should successfully return examples map", func(t *testing.T) {
+		client, err := NewExamplesClient(successTestServer.URL)
+		require.NoError(t, err)
+
+		examplesMap, err := client.GetAllExamplesAsLocationIndexedMap()
+		assert.Len(t, examplesMap, len(repositoryIndexModel.Examples.UDG))
+		assert.Equal(t, repositoryIndexModel.Examples.UDG[0], examplesMap[repositoryIndexModel.Examples.UDG[0].Location])
+	})
+}
+
 func createRepositoryTestServer(t *testing.T, statusCode int) *httptest.Server {
 	t.Helper()
 	repositoryIndexHandler := func(w http.ResponseWriter, r *http.Request) {

--- a/clients/examplesrepo/utils.go
+++ b/clients/examplesrepo/utils.go
@@ -20,3 +20,17 @@ func MergeExamples(index *RepositoryIndex) []ExampleMetadata {
 
 	return examples
 }
+
+func ExamplesAsLocationIndexedMap(index *RepositoryIndex) map[string]ExampleMetadata {
+	examples := MergeExamples(index)
+	if len(examples) == 0 {
+		return nil
+	}
+
+	examplesMap := make(map[string]ExampleMetadata, len(examples))
+	for _, example := range examples {
+		examplesMap[example.Location] = example
+	}
+
+	return examplesMap
+}

--- a/clients/examplesrepo/utils_test.go
+++ b/clients/examplesrepo/utils_test.go
@@ -58,3 +58,34 @@ func TestMergeExamples(t *testing.T) {
 		assert.Equal(t, expectedExamples, examples)
 	})
 }
+
+func TestExamplesAsLocationIndexedMap(t *testing.T) {
+	t.Run("should return nil when no examples are available", func(t *testing.T) {
+		examplesMap := ExamplesAsLocationIndexedMap(nil)
+		assert.Nil(t, examplesMap)
+	})
+
+	t.Run("should successfully create an examples map", func(t *testing.T) {
+		udgExample1 := ExampleMetadata{
+			Location: "udg/example-1",
+		}
+
+		udgExample2 := ExampleMetadata{
+			Location: "udg/example-2",
+		}
+
+		index := RepositoryIndex{
+			Examples: ExamplesCategories{
+				UDG: []ExampleMetadata{
+					udgExample1,
+					udgExample2,
+				},
+			},
+		}
+
+		examplesMap := ExamplesAsLocationIndexedMap(&index)
+		assert.Len(t, examplesMap, 2)
+		assert.Equal(t, udgExample1, examplesMap[udgExample1.Location])
+		assert.Equal(t, udgExample2, examplesMap[udgExample2.Location])
+	})
+}

--- a/cmd/examples_show.go
+++ b/cmd/examples_show.go
@@ -1,0 +1,34 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+// examplesShowCmd represents a command to show the details of a specific example
+var examplesShowCmd = &cobra.Command{
+	Use:   "show",
+	Short: "Shows details of a specific example by using its location",
+	Long: `This command will show the details of a specific example by providing the location. The location can be
+	determined by using the 'examples' command.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		err := processExampleDetails(cmd)
+		if err != nil {
+			fmt.Println("Error: ", err)
+			os.Exit(1)
+		}
+	},
+}
+
+func init() {
+	examplesCmd.AddCommand(examplesShowCmd)
+
+	examplesShowCmd.Flags().StringP("location", "l", "", "Location to example")
+	err := examplesShowCmd.MarkFlagRequired("location")
+	if err != nil {
+		fmt.Println("Error: ", err)
+		os.Exit(1)
+	}
+}

--- a/cmd/shared.go
+++ b/cmd/shared.go
@@ -270,12 +270,12 @@ func processExamplesList() error {
 		return err
 	}
 
-	index, err := client.GetRepositoryIndex()
+	examples, err := client.GetAllExamples()
 	if err != nil {
 		return err
 	}
 
-	if !examplesrepo.IndexHasExamples(index) {
+	if len(examples) == 0 {
 		fmt.Println("no examples found")
 		return nil
 	}
@@ -286,7 +286,7 @@ func processExamplesList() error {
 		return err
 	}
 
-	for _, example := range examplesrepo.MergeExamples(index) {
+	for _, example := range examples {
 		_, err = fmt.Fprintf(tabbedResultWriter, "%s\t%s\t%s\n", example.Location, example.Name, example.Description)
 		if err != nil {
 			return err

--- a/cmd/shared_test.go
+++ b/cmd/shared_test.go
@@ -1,0 +1,38 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/TykTechnologies/tyk-sync/clients/examplesrepo"
+)
+
+func TestGenerateExampleDetailsString(t *testing.T) {
+	example := examplesrepo.ExampleMetadata{
+		Location:      "udg/example",
+		Name:          "An Example",
+		Description:   "An example that can be published",
+		Features:      []string{"rest", "graphql", "kafka"},
+		MinTykVersion: "5.0",
+	}
+
+	exampleDetails := generateExampleDetailsString(example)
+	expectedExampleDetails := `LOCATION
+udg/example
+
+NAME
+An Example
+
+DESCRIPTION
+An example that can be published
+
+FEATURES
+- rest
+- graphql
+- kafka
+
+MIN TYK VERSION
+5.0`
+	assert.Equal(t, expectedExampleDetails, exampleDetails)
+}


### PR DESCRIPTION
This PR adds an `examples show` command which retrieves the details of an example when providing the location via `--location=` flag.

Output looks like this:
```
LOCATION
udg/first-demo

NAME
First UDG Demo

DESCRIPTION
This UDG demo is very simple

FEATURES
- GraphQL DataSource
- REST DataSource

MIN TYK VERSION
3
```

PR also contains a slight refactor to abstract the fetch of examples into the examples client.