### PR TITLE
add examples publish command

### DIFF
--- a/clients/examplesrepo/client.go
+++ b/clients/examplesrepo/client.go
@@ -11,6 +11,7 @@ import (
 
 const (
 	RepoRootUrl   = "https://raw.githubusercontent.com/TykTechnologies/tyk-examples/main"
+	RepoGitUrl    = "https://github.com/TykTechnologies/tyk-examples.git"
 	RepoIndexFile = "repository.json"
 )
 

--- a/cmd/examples_publish.go
+++ b/cmd/examples_publish.go
@@ -1,0 +1,46 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+// examplesPublishCmd represents a command to publish a specific example to a gateway or dashboard
+var examplesPublishCmd = &cobra.Command{
+	Use:   "publish",
+	Short: "Publish a specific example to a gateway or dashboard by using its location",
+	Long: `This command will publish a specific example by providing the location to a gateway or dashboard. The location can be
+	determined by using the 'examples' command.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		verificationError := verifyArguments(cmd)
+		if verificationError != nil {
+			fmt.Println(verificationError)
+			os.Exit(1)
+		}
+
+		err := processExamplePublish(cmd, args)
+		if err != nil {
+			fmt.Println("Error: ", err)
+			os.Exit(1)
+		}
+	},
+}
+
+func init() {
+	examplesCmd.AddCommand(examplesPublishCmd)
+
+	examplesPublishCmd.Flags().StringP("gateway", "g", "", "Fully qualified gateway target URL")
+	examplesPublishCmd.Flags().StringP("dashboard", "d", "", "Fully qualified dashboard target URL")
+	examplesPublishCmd.Flags().StringP("key", "k", "", "Key file location for auth (optional)")
+	examplesPublishCmd.Flags().StringP("branch", "b", "refs/heads/main", "Branch to use (defaults to refs/heads/main)")
+	examplesPublishCmd.Flags().StringP("secret", "s", "", "Your API secret")
+	examplesPublishCmd.Flags().Bool("test", false, "Use test publisher, output results to stdio")
+	examplesPublishCmd.Flags().StringP("location", "l", "", "Location to example")
+	err := examplesPublishCmd.MarkFlagRequired("location")
+	if err != nil {
+		fmt.Println("Error: ", err)
+		os.Exit(1)
+	}
+}

--- a/cmd/shared.go
+++ b/cmd/shared.go
@@ -122,19 +122,19 @@ func getAuthAndBranch(cmd *cobra.Command, args []string) ([]byte, string) {
 
 func NewGetter(cmd *cobra.Command, args []string) (tyk_vcs.Getter, error) {
 	filePath, _ := cmd.Flags().GetString("path")
+	subdirectoryPath, _ := cmd.Flags().GetString("location")
 	if filePath != "" {
-		return tyk_vcs.NewFSGetter(filePath)
+		return tyk_vcs.NewFSGetter(filePath, subdirectoryPath)
 	}
 
 	if len(args) == 0 {
 		return nil, errors.New("must specify repo address to pull from as first argument")
 	}
 	auth, branch := getAuthAndBranch(cmd, args)
-	return tyk_vcs.NewGGetter(args[0], branch, auth)
+	return tyk_vcs.NewGGetter(args[0], branch, auth, subdirectoryPath)
 }
 
 func doGetData(cmd *cobra.Command, args []string) ([]objects.DBApiDefinition, []objects.Policy, error) {
-
 	getter, err := NewGetter(cmd, args)
 	if err != nil {
 		return nil, nil, err
@@ -294,6 +294,13 @@ func processExamplesList() error {
 	}
 
 	return tabbedResultWriter.Flush()
+}
+
+func processExamplePublish(cmd *cobra.Command, args []string) error {
+	if len(args) == 0 {
+		args = append(args, examplesrepo.RepoGitUrl)
+	}
+	return processPublish(cmd, args)
 }
 
 func processExampleDetails(cmd *cobra.Command) error {

--- a/tyk-vcs/getter_test.go
+++ b/tyk-vcs/getter_test.go
@@ -1,20 +1,23 @@
 package tyk_vcs
 
 import (
+	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 const REPO string = "https://github.com/lonelycode/integration-test.git"
 
 func TestNewGGetter(t *testing.T) {
-	_, e := NewGGetter(REPO, "refs/heads/master", []byte{})
+	_, e := NewGGetter(REPO, "refs/heads/master", []byte{}, "")
 	if e != nil {
 		t.Fatal(e)
 	}
 }
 
 func TestGitGetter_FetchRepo(t *testing.T) {
-	g, e := NewGGetter(REPO, "refs/heads/master", []byte{})
+	g, e := NewGGetter(REPO, "refs/heads/master", []byte{}, "")
 	if e != nil {
 		t.Fatal(e)
 	}
@@ -26,7 +29,7 @@ func TestGitGetter_FetchRepo(t *testing.T) {
 }
 
 func TestGitGetter_FetchTykSpec(t *testing.T) {
-	g, e := NewGGetter(REPO, "refs/heads/master", []byte{})
+	g, e := NewGGetter(REPO, "refs/heads/master", []byte{}, "")
 	if e != nil {
 		t.Fatal(e)
 	}
@@ -47,7 +50,7 @@ func TestGitGetter_FetchTykSpec(t *testing.T) {
 }
 
 func TestGitGetter_FetchAPIDef(t *testing.T) {
-	g, e := NewGGetter(REPO, "refs/heads/master", []byte{})
+	g, e := NewGGetter(REPO, "refs/heads/master", []byte{}, "")
 	if e != nil {
 		t.Fatal(e)
 	}
@@ -79,7 +82,7 @@ func TestGitGetter_FetchAPIDef(t *testing.T) {
 }
 
 func TestGitGetter_FetchAPIDef_Swagger(t *testing.T) {
-	g, e := NewGGetter(REPO, "refs/heads/swagger-test", []byte{})
+	g, e := NewGGetter(REPO, "refs/heads/swagger-test", []byte{}, "")
 	if e != nil {
 		t.Fatal(e)
 	}
@@ -124,4 +127,23 @@ func TestGitGetter_FetchAPIDef_Swagger(t *testing.T) {
 	if ad.Proxy.ListenPath != ts.Files[0].OAS.OverrideListenPath {
 		t.Fatalf("Target Was not properly set, expected: %v, got %v", ad.Proxy.ListenPath, ts.Files[0].OAS.OverrideListenPath)
 	}
+}
+
+func TestGetFilepath(t *testing.T) {
+	t.Run("filepath without path segments", func(t *testing.T) {
+		fullPath := getFilepath(".tyk.json", "")
+		assert.Equal(t, ".tyk.json", fullPath)
+	})
+	t.Run("filepath with path segments", func(t *testing.T) {
+		fullPath := getFilepath(".tyk-json", "examples/udg/simple")
+		assert.Equal(t, filepath.Clean("examples/udg/simple/.tyk-json"), fullPath)
+	})
+	t.Run("filepath with multiple separators in path segments", func(t *testing.T) {
+		fullPath := getFilepath(".tyk-json", "examples////udg///simple////")
+		assert.Equal(t, filepath.Clean("examples/udg/simple/.tyk-json"), fullPath)
+	})
+	t.Run("filepath with multiple path segments", func(t *testing.T) {
+		fullPath := getFilepath(".tyk-json", "examples//udg//", "/simple")
+		assert.Equal(t, filepath.Clean("examples/udg/simple/.tyk-json"), fullPath)
+	})
 }


### PR DESCRIPTION
This PR adds the new command `examples publish` which can be used to publish a specific example from a subdirectory to dashboard or API (it uses the same `publish` code).

Usage:
```
tyk-sync examples publish -d=http://localhost:3000 -s=secret -l=udg/first-demo
```
or with optional git repository URL:
```
tyk-sync examples publish -d=http://localhost:3000 -s=secret -l=udg/first-demo https://github.com/pvormste/tyk-examples.git
```

Output (example):
```
Fetched 1 definitions
Fetched 0 policies
Using publisher: Dashboard Publisher
org override detected, setting.
Creating API 0: sync-countries
--> Status: OK, ID:d86db3f61a3b465376823cf22d393343
Updating API 0: sync-countries
--> Status: OK, ID:d86db3f61a3b465376823cf22d393343
org override detected, setting.
Done
```