### PR TITLE
Fix the installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Currently the application is available via Go, Docker and in packagecloud, so to
  go install github.com/TykTechnologies/tyk-sync@latest 
  ```
  
- You can also  or download the binaries from the releases page.
+ You can also download the binaries from the releases page.
  
 This should make the `tyk-sync` command available to your console.
 


### PR DESCRIPTION
When a user tries to use `go get ` the current instructions to install they will get the error `go get is no longer supported outside a module`.

<img width="816" alt="Screenshot 2023-03-28 at 11 08 19" src="https://user-images.githubusercontent.com/8012032/228171645-2517b4ff-5e6a-44a9-a198-3c33a017d652.png">

This is because go now requires users to use `go install` instead. This pull request changes the instructions from `go get` to `go install`
