### PR TITLE
TT-9292 Latest goreleaser has breaking change in replacements, pin 1.18

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,7 +110,7 @@ jobs:
 
       - uses: goreleaser/goreleaser-action@v2
         with:
-          version: 1.19.2
+          version: 1.18.2
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,7 +110,7 @@ jobs:
 
       - uses: goreleaser/goreleaser-action@v2
         with:
-          version: latest
+          version: 1.19.2
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
nfpmreplacements have been removed in latest version

https://goreleaser.com/deprecations/#nfpmsreplacements

pin 1.18 for now, address update later


https://tyktech.atlassian.net/browse/TT-9292

