### PR TITLE
[TT-9628/TT-9718] Disable OAS update endpoint usage, use classic endpoint instead

### DIFF
--- a/clients/dashboard/apis.go
+++ b/clients/dashboard/apis.go
@@ -247,10 +247,6 @@ func (c *Client) UpdateAPIs(apiDefs *[]objects.DBApiDefinition) error {
 		endpoint := endpointAPIs
 		var payload interface{}
 		payload = asDBDef
-		if apiDef.IsOAS {
-			endpoint = endpointOASAPIs
-			payload = asDBDef.OAS
-		}
 
 		data, err := json.Marshal(payload)
 		if err != nil {

--- a/clients/dashboard/client.go
+++ b/clients/dashboard/client.go
@@ -20,7 +20,6 @@ type Client struct {
 
 const (
 	endpointAPIs     string = "/api/apis"
-	endpointOASAPIs  string = "/api/apis/oas"
 	endpointPolicies string = "/api/portal/policies"
 	endpointCerts    string = "/api/certs"
 	endpointUsers    string = "/api/users"


### PR DESCRIPTION
When API update operation is made by `tyk-sync`, it uses oas api update endpoint of `tyk-analytics` which doesn't respect some features that are not yet available in OAS. So, it should use classic api definition format to cover all features.

This requires the dashboard classic API endpoint to accept `"is_oas": true` payloads. That will be handled with this PR: https://github.com/TykTechnologies/tyk-analytics/pull/3384

Parent: https://tyktech.atlassian.net/browse/TT-9628
Subtask: https://tyktech.atlassian.net/browse/TT-9718