### PR TITLE
[TT-10190] Add allow-unsafe-oas flag

### DIFF
--- a/cli-publisher/dashboard.go
+++ b/cli-publisher/dashboard.go
@@ -8,9 +8,10 @@ import (
 )
 
 type DashboardPublisher struct {
-	Secret      string
-	Hostname    string
-	OrgOverride string
+	Secret         string
+	Hostname       string
+	OrgOverride    string
+	AllowUnsafeOAS bool
 }
 
 func (p *DashboardPublisher) enforceOrgID(apiDefs *[]objects.DBApiDefinition) {
@@ -34,7 +35,7 @@ func (p *DashboardPublisher) enforceOrgIDForPolicies(pols *[]objects.Policy) {
 }
 
 func (p *DashboardPublisher) CreateAPIs(apiDefs *[]objects.DBApiDefinition) error {
-	c, err := dashboard.NewDashboardClient(p.Hostname, p.Secret, p.OrgOverride)
+	c, err := dashboard.NewDashboardClient(p.Hostname, p.Secret, p.OrgOverride, p.AllowUnsafeOAS)
 	if err != nil {
 		return err
 	}
@@ -47,7 +48,7 @@ func (p *DashboardPublisher) CreateAPIs(apiDefs *[]objects.DBApiDefinition) erro
 }
 
 func (p *DashboardPublisher) UpdateAPIs(apiDefs *[]objects.DBApiDefinition) error {
-	c, err := dashboard.NewDashboardClient(p.Hostname, p.Secret, p.OrgOverride)
+	c, err := dashboard.NewDashboardClient(p.Hostname, p.Secret, p.OrgOverride, p.AllowUnsafeOAS)
 	if err != nil {
 		return err
 	}
@@ -60,7 +61,7 @@ func (p *DashboardPublisher) UpdateAPIs(apiDefs *[]objects.DBApiDefinition) erro
 }
 
 func (p *DashboardPublisher) SyncAPIs(apiDefs []objects.DBApiDefinition) error {
-	c, err := dashboard.NewDashboardClient(p.Hostname, p.Secret, p.OrgOverride)
+	c, err := dashboard.NewDashboardClient(p.Hostname, p.Secret, p.OrgOverride, p.AllowUnsafeOAS)
 	if err != nil {
 		return err
 	}

--- a/cli-publisher/dashboard.go
+++ b/cli-publisher/dashboard.go
@@ -94,7 +94,7 @@ func (p *DashboardPublisher) Name() string {
 }
 
 func (p *DashboardPublisher) CreatePolicies(pols *[]objects.Policy) error {
-	c, err := dashboard.NewDashboardClient(p.Hostname, p.Secret, p.OrgOverride)
+	c, err := dashboard.NewDashboardClient(p.Hostname, p.Secret, p.OrgOverride, p.AllowUnsafeOAS)
 	if err != nil {
 		return err
 	}
@@ -107,7 +107,7 @@ func (p *DashboardPublisher) CreatePolicies(pols *[]objects.Policy) error {
 }
 
 func (p *DashboardPublisher) UpdatePolicies(pols *[]objects.Policy) error {
-	c, err := dashboard.NewDashboardClient(p.Hostname, p.Secret, p.OrgOverride)
+	c, err := dashboard.NewDashboardClient(p.Hostname, p.Secret, p.OrgOverride, p.AllowUnsafeOAS)
 	if err != nil {
 		return err
 	}
@@ -120,7 +120,7 @@ func (p *DashboardPublisher) UpdatePolicies(pols *[]objects.Policy) error {
 }
 
 func (p *DashboardPublisher) SyncPolicies(pols []objects.Policy) error {
-	c, err := dashboard.NewDashboardClient(p.Hostname, p.Secret, p.OrgOverride)
+	c, err := dashboard.NewDashboardClient(p.Hostname, p.Secret, p.OrgOverride, p.AllowUnsafeOAS)
 	if err != nil {
 		return err
 	}

--- a/clients/dashboard/apis.go
+++ b/clients/dashboard/apis.go
@@ -247,6 +247,10 @@ func (c *Client) UpdateAPIs(apiDefs *[]objects.DBApiDefinition) error {
 		endpoint := endpointAPIs
 		var payload interface{}
 		payload = asDBDef
+		if apiDef.IsOAS && !c.allowUnsafeOAS {
+			endpoint = endpointOASAPIs
+			payload = asDBDef.OAS
+		}
 
 		data, err := json.Marshal(payload)
 		if err != nil {

--- a/clients/dashboard/client.go
+++ b/clients/dashboard/client.go
@@ -16,10 +16,12 @@ type Client struct {
 	isCloud            bool
 	InsecureSkipVerify bool
 	OrgID              string
+	allowUnsafeOAS     bool
 }
 
 const (
 	endpointAPIs     string = "/api/apis"
+	endpointOASAPIs  string = "/api/apis/oas"
 	endpointPolicies string = "/api/portal/policies"
 	endpointCerts    string = "/api/certs"
 	endpointUsers    string = "/api/users"
@@ -31,11 +33,17 @@ var (
 	UseCreateError    error = errors.New("Object does not exist, use create()")
 )
 
-func NewDashboardClient(url, secret, orgID string) (*Client, error) {
+func NewDashboardClient(url, secret, orgID string, allowUnsafeOAS ...bool) (*Client, error) {
+	unsafeOAS := false
+	if len(allowUnsafeOAS) > 0 {
+		unsafeOAS = allowUnsafeOAS[0]
+	}
+
 	client := &Client{
-		url:     url,
-		secret:  secret,
-		isCloud: strings.Contains(url, "tyk.io"),
+		url:            url,
+		secret:         secret,
+		isCloud:        strings.Contains(url, "tyk.io"),
+		allowUnsafeOAS: unsafeOAS,
 	}
 
 	if orgID == "" {

--- a/clients/dashboard/client.go
+++ b/clients/dashboard/client.go
@@ -33,17 +33,12 @@ var (
 	UseCreateError    error = errors.New("Object does not exist, use create()")
 )
 
-func NewDashboardClient(url, secret, orgID string, allowUnsafeOAS ...bool) (*Client, error) {
-	unsafeOAS := false
-	if len(allowUnsafeOAS) > 0 {
-		unsafeOAS = allowUnsafeOAS[0]
-	}
-
+func NewDashboardClient(url, secret, orgID string, allowUnsafeOAS bool) (*Client, error) {
 	client := &Client{
 		url:            url,
 		secret:         secret,
 		isCloud:        strings.Contains(url, "tyk.io"),
-		allowUnsafeOAS: unsafeOAS,
+		allowUnsafeOAS: allowUnsafeOAS,
 	}
 
 	if orgID == "" {

--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -50,7 +50,7 @@ var dumpCmd = &cobra.Command{
 
 		fmt.Printf("Extracting APIs and Policies from %v\n", dbString)
 
-		c, err := dashboard.NewDashboardClient(dbString, secret, "")
+		c, err := dashboard.NewDashboardClient(dbString, secret, "", false)
 		if err != nil {
 			fmt.Println(err)
 		}

--- a/cmd/publish.go
+++ b/cmd/publish.go
@@ -39,7 +39,7 @@ func init() {
 	publishCmd.Flags().StringP("secret", "s", "", "Your API secret")
 	publishCmd.Flags().StringP("path", "p", "", "Source directory for definition files (optional)")
 	publishCmd.Flags().Bool("test", false, "Use test publisher, output results to stdio")
-	publishCmd.Flags().Bool("allow-unsafe-oas", false, "Use classic API endpoints in dashboard for OAS update")
+	publishCmd.Flags().Bool("allow-unsafe-oas", false, "Use classic API endpoints in dashboard for OAS APIs during publish")
 	publishCmd.Flags().StringSlice("policies", []string{}, "Specific Policies ids to publish")
 	publishCmd.Flags().StringSlice("apis", []string{}, "Specific Apis ids to publish")
 }

--- a/cmd/publish.go
+++ b/cmd/publish.go
@@ -2,8 +2,9 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/spf13/cobra"
 	"os"
+
+	"github.com/spf13/cobra"
 )
 
 // publishCmd represents the publish command
@@ -38,6 +39,7 @@ func init() {
 	publishCmd.Flags().StringP("secret", "s", "", "Your API secret")
 	publishCmd.Flags().StringP("path", "p", "", "Source directory for definition files (optional)")
 	publishCmd.Flags().Bool("test", false, "Use test publisher, output results to stdio")
+	publishCmd.Flags().Bool("allow-unsafe-oas", false, "Use classic API endpoints in dashboard for OAS update")
 	publishCmd.Flags().StringSlice("policies", []string{}, "Specific Policies ids to publish")
 	publishCmd.Flags().StringSlice("apis", []string{}, "Specific Apis ids to publish")
 }

--- a/cmd/shared.go
+++ b/cmd/shared.go
@@ -10,10 +10,10 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/TykTechnologies/tyk-sync/cli-publisher"
+	cli_publisher "github.com/TykTechnologies/tyk-sync/cli-publisher"
 	"github.com/TykTechnologies/tyk-sync/clients/examplesrepo"
 	"github.com/TykTechnologies/tyk-sync/clients/objects"
-	"github.com/TykTechnologies/tyk-sync/tyk-vcs"
+	tyk_vcs "github.com/TykTechnologies/tyk-sync/tyk-vcs"
 )
 
 var isGateway bool
@@ -68,10 +68,13 @@ func getPublisher(cmd *cobra.Command, args []string) (tyk_vcs.Publisher, error) 
 
 		orgOverride, _ := cmd.Flags().GetString("org")
 
+		allowUnsafeOAS, _ := cmd.Flags().GetBool("allow-unsafe-oas")
+
 		newDashPublisher := &cli_publisher.DashboardPublisher{
-			Secret:      secret,
-			Hostname:    dbString,
-			OrgOverride: orgOverride,
+			Secret:         secret,
+			Hostname:       dbString,
+			OrgOverride:    orgOverride,
+			AllowUnsafeOAS: allowUnsafeOAS,
 		}
 
 		return newDashPublisher, nil

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -41,7 +41,7 @@ func init() {
 	syncCmd.Flags().StringP("org", "o", "", "org ID override")
 	syncCmd.Flags().StringP("path", "p", "", "Source directory for definition files (optional)")
 	syncCmd.Flags().Bool("test", false, "Use test publisher, output results to stdio")
-	syncCmd.Flags().Bool("allow-unsafe-oas", false, "Use classic API endpoints in dashboard for OAS update")
+	syncCmd.Flags().Bool("allow-unsafe-oas", false, "Use classic API endpoints in dashboard for OAS APIs during sync")
 	syncCmd.Flags().StringSlice("policies", []string{}, "Specific Policies ids to sync")
 	syncCmd.Flags().StringSlice("apis", []string{}, "Specific Apis ids to sync")
 }

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -2,8 +2,9 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/spf13/cobra"
 	"os"
+
+	"github.com/spf13/cobra"
 )
 
 // syncCmd represents the sync command
@@ -40,6 +41,7 @@ func init() {
 	syncCmd.Flags().StringP("org", "o", "", "org ID override")
 	syncCmd.Flags().StringP("path", "p", "", "Source directory for definition files (optional)")
 	syncCmd.Flags().Bool("test", false, "Use test publisher, output results to stdio")
+	syncCmd.Flags().Bool("allow-unsafe-oas", false, "Use classic API endpoints in dashboard for OAS update")
 	syncCmd.Flags().StringSlice("policies", []string{}, "Specific Policies ids to sync")
 	syncCmd.Flags().StringSlice("apis", []string{}, "Specific Apis ids to sync")
 }

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -51,7 +51,7 @@ func init() {
 	updateCmd.Flags().StringP("secret", "s", "", "Your API secret")
 	updateCmd.Flags().StringP("path", "p", "", "Source directory for definition files (optional)")
 	updateCmd.Flags().Bool("test", false, "Use test publisher, output results to stdio")
-	updateCmd.Flags().Bool("allow-unsafe-oas", false, "Use classic API endpoints in dashboard for OAS update")
+	updateCmd.Flags().Bool("allow-unsafe-oas", false, "Use classic API endpoints in dashboard for OAS APIs during update")
 	updateCmd.Flags().StringSlice("policies", []string{}, "Specific Policies ids to update")
 	updateCmd.Flags().StringSlice("apis", []string{}, "Specific Apis ids to update")
 }

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -16,8 +16,9 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/spf13/cobra"
 	"os"
+
+	"github.com/spf13/cobra"
 )
 
 // updateCmd represents the update command
@@ -50,6 +51,7 @@ func init() {
 	updateCmd.Flags().StringP("secret", "s", "", "Your API secret")
 	updateCmd.Flags().StringP("path", "p", "", "Source directory for definition files (optional)")
 	updateCmd.Flags().Bool("test", false, "Use test publisher, output results to stdio")
+	updateCmd.Flags().Bool("allow-unsafe-oas", false, "Use classic API endpoints in dashboard for OAS update")
 	updateCmd.Flags().StringSlice("policies", []string{}, "Specific Policies ids to update")
 	updateCmd.Flags().StringSlice("apis", []string{}, "Specific Apis ids to update")
 }


### PR DESCRIPTION
This PR adds `--allow-unsafe-oas` flag to `update`, `sync` and `publish` commands so that if it is set, it will stop using `oas` API update endpoint in the dashboard. It will use classic API update endpoints instead.