### PR TITLE
[TT-11743] - Tyk Sync OAS Support: dump command

### DIFF
--- a/cli-publisher/dashboard.go
+++ b/cli-publisher/dashboard.go
@@ -73,6 +73,10 @@ func (p *DashboardPublisher) SyncAPIs(apiDefs []objects.DBApiDefinition) error {
 	if p.OrgOverride != "" {
 		fixedDefs := make([]objects.DBApiDefinition, len(apiDefs))
 		for i, a := range apiDefs {
+			if a.APIDefinition == nil {
+				continue
+			}
+
 			newDef := a
 			newDef.OrgID = p.OrgOverride
 			fixedDefs[i] = newDef

--- a/clients/objects/apidef.go
+++ b/clients/objects/apidef.go
@@ -14,6 +14,7 @@ func NewDefinition() *DBApiDefinition {
 type DBApiDefinition struct {
 	*APIDefinition  `bson:"api_definition" json:"api_definition"`
 	OAS             *oas.OAS        `json:"oas,omitempty"`
+	Categories      []string        `bson:"categories" json:"categories,omitempty"`
 	HookReferences  []interface{}   `bson:"hook_references" json:"hook_references"`
 	IsSite          bool            `bson:"is_site" json:"is_site"`
 	SortBy          int             `bson:"sort_by" json:"sort_by"`

--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -205,6 +205,13 @@ var dumpCmd = &cobra.Command{
 							found = true
 						}
 					}
+
+					for _, api := range oasApisDB {
+						if api.APIID == accessRights.APIID {
+							found = true
+						}
+					}
+
 					if !found {
 						fmt.Println("--> [WARNING] Policy ", policy.ID, " has access rights over API ID ", accessRights.APIID, " and that API it's not imported. It might cause some problems in the future.")
 					}
@@ -214,7 +221,7 @@ var dumpCmd = &cobra.Command{
 
 		// If we have selected APIs specified we're going to check if we're importing all the necessary policies
 		if len(wantedAPIs) > 0 {
-			//checking selected APIs  -  Policies integrity
+			// checking selected APIs  -  Policies integrity
 			for _, api := range apis {
 				for _, provider := range api.OpenIDOptions.Providers {
 					for _, id := range provider.ClientIDs {

--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -170,25 +170,6 @@ var dumpCmd = &cobra.Command{
 
 		oasApiFiles := make([]string, len(oasApisDB))
 		for i, oasApi := range oasApisDB {
-			//j, jerr := oasApi.OAS.MarshalJSON()
-			//if jerr != nil {
-			//	fmt.Printf("OAS JSON Encoding error: %v\n", jerr.Error())
-			//	return
-			//}
-
-			//var data map[string]interface{}
-			//if err := json.Unmarshal(j, &data); err != nil {
-			//	fmt.Println("failed to unmarshal again")
-			//	return
-			//}
-			//
-			//// Marshal the map with indentation
-			//j, jerr = json.MarshalIndent(data, "", " ")
-			//if err != nil {
-			//	fmt.Println("FAILED third step")
-			//	return
-			//}
-
 			j, jerr := json.MarshalIndent(oasApi, "", "  ")
 			if jerr != nil {
 				fmt.Printf("OASAPI JSON Encoding error: %v\n", jerr.Error())

--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+
 	"gopkg.in/mgo.v2/bson"
 
 	"encoding/json"
@@ -144,6 +145,8 @@ var dumpCmd = &cobra.Command{
 				}
 				apis[i] = fullAPI
 			}
+
+			apis, oasApisDB = extractOASApis(apis)
 		}
 
 		fmt.Printf("--> Fetched %v Classic APIs\n", len(apis))

--- a/tyk-vcs/getter.go
+++ b/tyk-vcs/getter.go
@@ -158,6 +158,10 @@ func fetchAPIDefinitionsDirect(fs billy.Filesystem, spec *TykSourceSpec, subdire
 	defNames := spec.Files
 	defs := make([]objects.DBApiDefinition, len(defNames))
 	for i, defInfo := range defNames {
+		if defInfo.File == "" {
+			continue
+		}
+		
 		defFile, err := fs.Open(getFilepath(defInfo.File, subdirectoryPath))
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Allow users to dump OAS APIs by using dump command.

Integrate new OAS API endpoints to Tyk Sync to make it work with OAS APIs. So that users can dump their Tyk installation without providing any additional configuration flags such as --allow-unsafe-oas and OAS can be dumped in a fully functional way including categories.

Internal ticket: https://tyktech.atlassian.net/browse/TT-11743