### PR TITLE
[TT-11744] Deprecate `allow-unsafe-oas` flag of sync command

### DIFF
--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -1,0 +1,51 @@
+name: golangci-lint
+
+on:
+  push:
+    branches:
+      - master
+    paths: 
+      - '**.go'
+
+  pull_request:
+    branches:
+      - master
+    paths: 
+      - '**.go'
+
+jobs:
+  golangci:
+    name: linter
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.21
+      - name: check out code
+        uses: actions/checkout@v3
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
+          version: v1.55.2
+
+          # Optional: golangci-lint command line arguments.
+          args: --verbose --timeout=5m
+
+          # If set to true and the action runs on a pull request - the action outputs only newly found issues
+          only-new-issues: true
+
+          # Optional: working directory, useful for monorepos
+          # working-directory: somedir
+
+          # Optional: show only new issues if it's a pull request. The default value is `false`.
+          # only-new-issues: true
+
+          # Optional: if set to true then the action will use pre-installed Go.
+          # skip-go-installation: true
+
+          # Optional: if set to true then the action don't cache or restore ~/go/pkg.
+          # skip-pkg-cache: true
+
+          # Optional: if set to true then the action don't cache or restore ~/.cache/go-build.
+          # skip-build-cache: true

--- a/clients/dashboard/apis.go
+++ b/clients/dashboard/apis.go
@@ -98,13 +98,15 @@ func (c *Client) FetchAPIs() (*APISResponse, error) {
 	}
 
 	var oasApis []oas.OAS
-	for i, _ := range apisResponse.Apis {
+
+	for i := range apisResponse.Apis {
 		if apisResponse.Apis[i].APIDefinition != nil && apisResponse.Apis[i].IsOAS {
 			oasApi, err := c.FetchOASAPI(apisResponse.Apis[i].APIID)
 			if err != nil {
 				fmt.Printf("Failed to fetch OAS API: %v, err: %v", apisResponse.Apis[i].APIID, err)
 				continue
 			}
+
 			oasApis = append(oasApis, *oasApi)
 		}
 	}
@@ -194,6 +196,7 @@ func (c *Client) CreateAPIs(apiDefs *[]objects.DBApiDefinition) error {
 		var data []byte
 
 		fullPath := urljoin.Join(c.url, endpointAPIs)
+
 		if asDBDef.APIDefinition != nil {
 			switch asDBDef.IsOAS {
 			case true:
@@ -276,8 +279,8 @@ func (c *Client) UpdateAPIs(apiDefs *[]objects.DBApiDefinition) error {
 	if err != nil {
 		return err
 	}
-	existingAPIs := resp.Apis
 
+	existingAPIs := resp.Apis
 	apiids, ids, slugs, paths := getAPIsIdentifiers(&existingAPIs)
 
 	for i := range *apiDefs {

--- a/clients/dashboard/client.go
+++ b/clients/dashboard/client.go
@@ -40,6 +40,7 @@ func (c *Client) UpdateOASCategory(oasApi *objects.DBApiDefinition) (*grequests.
 	}
 
 	fullPath := urljoin.Join(c.url, endpointOASAPIs, oasApi.APIID, endpointCategories)
+
 	putResp, err := grequests.Put(fullPath, &grequests.RequestOptions{
 		JSON: data,
 		Headers: map[string]string{

--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -1,12 +1,12 @@
 package cmd
 
 import (
-	"fmt"
-	"gopkg.in/mgo.v2/bson"
-
 	"encoding/json"
+	"fmt"
 	"os"
 	"path"
+
+	"gopkg.in/mgo.v2/bson"
 
 	"github.com/TykTechnologies/tyk-sync/clients/dashboard"
 	"github.com/TykTechnologies/tyk-sync/clients/objects"
@@ -160,7 +160,7 @@ var dumpCmd = &cobra.Command{
 
 			fname := fmt.Sprintf("api-%v.json", api.APIID)
 			p := path.Join(dir, fname)
-			err := os.WriteFile(p, j, 0644)
+			err := os.WriteFile(p, j, 0o644)
 			if err != nil {
 				fmt.Printf("Error writing file: %v\n", err)
 				return
@@ -183,7 +183,7 @@ var dumpCmd = &cobra.Command{
 
 			fname := fmt.Sprintf("oas-%v.json", name)
 			p := path.Join(dir, fname)
-			err := os.WriteFile(p, j, 0644)
+			err := os.WriteFile(p, j, 0o644)
 			if err != nil {
 				fmt.Printf("Error writing file: %v\n", err)
 				return
@@ -203,7 +203,9 @@ var dumpCmd = &cobra.Command{
 						}
 					}
 					if !found {
-						fmt.Println("--> [WARNING] Policy ", policy.ID, " has access rights over API ID ", accessRights.APIID, " and that API it's not imported. It might cause some problems in the future.")
+						fmt.Println("--> [WARNING] Policy ", policy.ID,
+							" has access rights over API ID ", accessRights.APIID,
+							" and that API it's not imported. It might cause some problems in the future.")
 					}
 				}
 			}
@@ -211,7 +213,7 @@ var dumpCmd = &cobra.Command{
 
 		// If we have selected APIs specified we're going to check if we're importing all the necessary policies
 		if len(wantedAPIs) > 0 {
-			//checking selected APIs  -  Policies integrity
+			// checking selected APIs  -  Policies integrity
 			for _, api := range apis {
 				for _, provider := range api.OpenIDOptions.Providers {
 					for _, id := range provider.ClientIDs {
@@ -244,7 +246,7 @@ var dumpCmd = &cobra.Command{
 
 			fname := fmt.Sprintf("policy-%v.json", pol.ID)
 			p := path.Join(dir, fname)
-			err := os.WriteFile(p, j, 0644)
+			err := os.WriteFile(p, j, 0o644)
 			if err != nil {
 				fmt.Printf("Error writing file: %v\n", err)
 				return
@@ -293,7 +295,7 @@ var dumpCmd = &cobra.Command{
 			return
 		}
 
-		if err := os.WriteFile(p, j, 0644); err != nil {
+		if err := os.WriteFile(p, j, 0o644); err != nil {
 			fmt.Printf("Error writing file: %v\n", err)
 			return
 		}

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -44,4 +44,6 @@ func init() {
 	syncCmd.Flags().Bool("allow-unsafe-oas", false, "Use Tyk Classic endpoints in Tyk Dashboard API for Tyk OAS APIs (optional)")
 	syncCmd.Flags().StringSlice("policies", []string{}, "Specific Policies ids to sync")
 	syncCmd.Flags().StringSlice("apis", []string{}, "Specific Apis ids to sync")
+
+	syncCmd.Flags().MarkDeprecated("allow-unsafe-oas", "allow-unsage-oas flag is deprecated")
 }

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -45,5 +45,7 @@ func init() {
 	syncCmd.Flags().StringSlice("policies", []string{}, "Specific Policies ids to sync")
 	syncCmd.Flags().StringSlice("apis", []string{}, "Specific Apis ids to sync")
 
-	syncCmd.Flags().MarkDeprecated("allow-unsafe-oas", "syncing of OAS should work without it")
+	if err := syncCmd.Flags().MarkDeprecated("allow-unsafe-oas", "syncing of OAS should work without it"); err != nil {
+		fmt.Println("failed to mark `allow-unsafe-oas` flag deprecated")
+	}
 }

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -45,5 +45,5 @@ func init() {
 	syncCmd.Flags().StringSlice("policies", []string{}, "Specific Policies ids to sync")
 	syncCmd.Flags().StringSlice("apis", []string{}, "Specific Apis ids to sync")
 
-	syncCmd.Flags().MarkDeprecated("allow-unsafe-oas", "allow-unsage-oas flag is deprecated")
+	syncCmd.Flags().MarkDeprecated("allow-unsafe-oas", "syncing of OAS should work without it")
 }

--- a/tyk-vcs/getter.go
+++ b/tyk-vcs/getter.go
@@ -161,7 +161,7 @@ func fetchAPIDefinitionsDirect(fs billy.Filesystem, spec *TykSourceSpec, subdire
 		if defInfo.File == "" {
 			continue
 		}
-		
+
 		defFile, err := fs.Open(getFilepath(defInfo.File, subdirectoryPath))
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
### Description
- Deprecated `allow-unsafe-oas` flag of sync command.
- Added workflow for running linter

### Related Issue
[TT-11744](https://tyktech.atlassian.net/browse/TT-11744)

[TT-11744]: https://tyktech.atlassian.net/browse/TT-11744?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ