### PR TITLE
[TT-11745] Deprecate --allow-unsafe-oas flag of update and publish command

### DIFF
--- a/cmd/publish.go
+++ b/cmd/publish.go
@@ -42,4 +42,8 @@ func init() {
 	publishCmd.Flags().Bool("allow-unsafe-oas", false, "Use Tyk Classic endpoints in Tyk Dashboard API for Tyk OAS APIs (optional)")
 	publishCmd.Flags().StringSlice("policies", []string{}, "Specific Policies ids to publish")
 	publishCmd.Flags().StringSlice("apis", []string{}, "Specific Apis ids to publish")
+
+	if err := publishCmd.Flags().MarkDeprecated("allow-unsafe-oas", "OAS API can published without the flag."); err != nil {
+		fmt.Printf("Failed to mark `allow-unsafe-oas` flag as deprecated: %v", err)
+	}
 }

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -44,4 +44,8 @@ func init() {
 	syncCmd.Flags().Bool("allow-unsafe-oas", false, "Use Tyk Classic endpoints in Tyk Dashboard API for Tyk OAS APIs (optional)")
 	syncCmd.Flags().StringSlice("policies", []string{}, "Specific Policies ids to sync")
 	syncCmd.Flags().StringSlice("apis", []string{}, "Specific Apis ids to sync")
+
+	if err := syncCmd.Flags().MarkDeprecated("allow-unsafe-oas", "OAS API can synced without the flag."); err != nil {
+		fmt.Printf("Failed to mark `allow-unsafe-oas` flag as deprecated: %v", err)
+	}
 }

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -54,4 +54,8 @@ func init() {
 	updateCmd.Flags().Bool("allow-unsafe-oas", false, "Use Tyk Classic endpoints in Tyk Dashboard API for Tyk OAS APIs (optional)")
 	updateCmd.Flags().StringSlice("policies", []string{}, "Specific Policies ids to update")
 	updateCmd.Flags().StringSlice("apis", []string{}, "Specific Apis ids to update")
+
+	if err := syncCmd.Flags().MarkDeprecated("allow-unsafe-oas", "OAS API can synced without the flag."); err != nil {
+		fmt.Printf("Failed to mark `allow-unsafe-oas` flag as deprecated: %v", err)
+	}
 }

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -55,7 +55,7 @@ func init() {
 	updateCmd.Flags().StringSlice("policies", []string{}, "Specific Policies ids to update")
 	updateCmd.Flags().StringSlice("apis", []string{}, "Specific Apis ids to update")
 
-	if err := syncCmd.Flags().MarkDeprecated("allow-unsafe-oas", "OAS API can synced without the flag."); err != nil {
+	if err := updateCmd.Flags().MarkDeprecated("allow-unsafe-oas", "OAS API can updated without the flag."); err != nil {
 		fmt.Printf("Failed to mark `allow-unsafe-oas` flag as deprecated: %v", err)
 	}
 }


### PR DESCRIPTION
### Description
Deprecated allow-unsafe-oas flag of update and publish command.

### Related Issue
[TT-11745](https://tyktech.atlassian.net/browse/TT-11745)

[TT-11745]: https://tyktech.atlassian.net/browse/TT-11745?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ