### PR TITLE
Remove OAS API key calculation based on non-existent 'slug' attribute

### DIFF
--- a/clients/dashboard/apis.go
+++ b/clients/dashboard/apis.go
@@ -3,6 +3,7 @@ package dashboard
 import (
 	"encoding/json"
 	"fmt"
+
 	"github.com/gofrs/uuid"
 
 	"github.com/TykTechnologies/storage/persistent/model"
@@ -448,10 +449,10 @@ func (c *Client) SyncAPIs(apiDefs []objects.DBApiDefinition) error {
 				return err
 			}
 		} else if def.OAS != nil {
-			if c.isCloud {
-				GitIDMap[def.Slug] = i
-				continue
-			}
+			// if c.isCloud {
+			// 	GitIDMap[def.Slug] = i
+			// 	continue
+			// }
 
 			id, err = parseId(def.GetAPIID(), def.GetDBID().Hex())
 			if err != nil {

--- a/clients/dashboard/apis.go
+++ b/clients/dashboard/apis.go
@@ -3,7 +3,6 @@ package dashboard
 import (
 	"encoding/json"
 	"fmt"
-
 	"github.com/gofrs/uuid"
 
 	"github.com/TykTechnologies/storage/persistent/model"


### PR DESCRIPTION
Remove incorrect map key calculation

## Description
the 'slug' value does not exist for OAS APIs

There is an ongoing discussion related to this issue with Carlos Villanúa <carlos@tyk.io>and Josh Blakeley <josh@tyk.io>
Please note, I did not apply changes made by format-check and linting, because they are irrelevant to my fix.

## Related Issue
N/A

## Motivation and Context
`tyk-sync sync` was deleting OAS APIs from the cloud dashboard

## Test Coverage For This Change
manually tested
there are no unit tests in this repo

## Screenshots (if appropriate)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If PRing from your fork, don't come from your `master`!
- [x] Make sure you are making a pull request against our **`master` branch** (left side). Also, it would be best if you started *your change* off *our latest `master`*.
- [ ] My change requires a change to the documentation.
    - [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Check your code additions will not fail linting checks:
  - [-] `gofmt -s -w .`
  - [-] `go vet ./...`
  - [ ] `golangci-lint run`