### PR TITLE
Adds --org flag to publish and update commands

### DIFF
--- a/cmd/publish.go
+++ b/cmd/publish.go
@@ -45,6 +45,7 @@ func init() {
 	publishCmd.Flags().StringP("key", "k", "", "Provide the location of the SSH key file for authentication to Git (optional)")
 	publishCmd.Flags().StringP("branch", "b", "refs/heads/master", "Specify the branch of the GitHub repository to use")
 	publishCmd.Flags().StringP("secret", "s", "", "API secret for accessing Dashboard or Gateway API (optional).  If not set, value of TYKGIT_DB_SECRET/TYKGIT_GW_SECRET environment variable will be used for dahboard or gateway respectively")
+	publishCmd.Flags().StringP("org", "o", "", "Override the organization ID to use for the synchronisation process (optional)")
 	publishCmd.Flags().StringP("path", "p", "", "Specify the source file directory where API configuration files are located (Required for synchronising from file system)")
 	publishCmd.Flags().Bool("test", false, "Use test publisher, output results to stdio")
 	publishCmd.Flags().Bool("allow-unsafe-oas", false, "Use Tyk Classic endpoints in Tyk Dashboard API for Tyk OAS APIs (optional)")

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -56,6 +56,7 @@ func init() {
 	updateCmd.Flags().StringP("key", "k", "", "Provide the location of the SSH key file for authentication to Git (optional)")
 	updateCmd.Flags().StringP("branch", "b", "refs/heads/master", "Specify the branch of the GitHub repository to use")
 	updateCmd.Flags().StringP("secret", "s", "", "API secret for accessing Dashboard or Gateway API (optional).  If not set, value of TYKGIT_DB_SECRET/TYKGIT_GW_SECRET environment variable will be used for dahboard or gateway respectively")
+	updateCmd.Flags().StringP("org", "o", "", "Override the organization ID to use for the synchronisation process (optional)")
 	updateCmd.Flags().StringP("path", "p", "", "Specify the source file directory where API configuration files are located (Required for synchronising from file system)")
 	updateCmd.Flags().Bool("test", false, "Use test publisher, output results to stdio")
 	updateCmd.Flags().Bool("allow-unsafe-oas", false, "Use Tyk Classic endpoints in Tyk Dashboard API for Tyk OAS APIs (optional)")


### PR DESCRIPTION
Enables the --org flag for the Update and Publish commands

## Description
By just adding the flags to the cobra command configuration it should be possible to use this flag, as the existing logic is already in place

## Motivation and Context
This is a useful feature and is also described by the examples, so it would be expected for it to be there.


## Screenshots (if appropriate)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If PRing from your fork, don't come from your `master`!
- [x] Make sure you are making a pull request against our **`master` branch** (left side). Also, it would be best if you started *your change* off *our latest `master`*.
- [x] My change requires a change to the documentation.
    - [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] Check your code additions will not fail linting checks:
  - [x] `gofmt -s -w .`
  - [x] `go vet ./...`
  - [ ] `golangci-lint run`